### PR TITLE
Make drawing errors shareable across threads

### DIFF
--- a/src/drawing/area.rs
+++ b/src/drawing/area.rs
@@ -89,7 +89,7 @@ impl<DB: DrawingBackend, CT: CoordTranslate + Clone> Clone for DrawingArea<DB, C
 
 /// The error description of any drawing area API
 #[derive(Debug)]
-pub enum DrawingAreaErrorKind<E: Error> {
+pub enum DrawingAreaErrorKind<E: Error + Send + Sync> {
     /// The error is due to drawing backend failure
     BackendError(DrawingErrorKind<E>),
     /// We are not able to get the mutable reference of the backend,
@@ -100,7 +100,7 @@ pub enum DrawingAreaErrorKind<E: Error> {
     LayoutError,
 }
 
-impl<E: Error> std::fmt::Display for DrawingAreaErrorKind<E> {
+impl<E: Error + Send + Sync> std::fmt::Display for DrawingAreaErrorKind<E> {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         match self {
             DrawingAreaErrorKind::BackendError(e) => write!(fmt, "backend error: {}", e),
@@ -112,7 +112,7 @@ impl<E: Error> std::fmt::Display for DrawingAreaErrorKind<E> {
     }
 }
 
-impl<E: Error> Error for DrawingAreaErrorKind<E> {}
+impl<E: Error + Send + Sync> Error for DrawingAreaErrorKind<E> {}
 
 #[allow(type_alias_bounds)]
 type DrawingAreaError<T: DrawingBackend> = DrawingAreaErrorKind<T::ErrorType>;

--- a/src/drawing/backend.rs
+++ b/src/drawing/backend.rs
@@ -6,14 +6,14 @@ pub type BackendCoord = (i32, i32);
 
 /// The error produced by a drawing backend
 #[derive(Debug)]
-pub enum DrawingErrorKind<E: Error> {
+pub enum DrawingErrorKind<E: Error + Send + Sync> {
     /// A drawing backend error
     DrawingError(E),
     /// A font rendering error
     FontError(FontError),
 }
 
-impl<E: Error> std::fmt::Display for DrawingErrorKind<E> {
+impl<E: Error + Send + Sync> std::fmt::Display for DrawingErrorKind<E> {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         match self {
             DrawingErrorKind::DrawingError(e) => write!(fmt, "Drawing backend error: {}", e),
@@ -22,7 +22,7 @@ impl<E: Error> std::fmt::Display for DrawingErrorKind<E> {
     }
 }
 
-impl<E: Error> Error for DrawingErrorKind<E> {}
+impl<E: Error + Send + Sync> Error for DrawingErrorKind<E> {}
 
 /// The style data for the backend drawing API
 pub trait BackendStyle {
@@ -50,7 +50,7 @@ impl<T: Color> BackendStyle for T {
 ///  will use the pixel-based approach to draw other types of low-level shapes.
 pub trait DrawingBackend {
     /// The error type reported by the backend
-    type ErrorType: Error;
+    type ErrorType: Error + Send + Sync;
 
     /// Get the dimension of the drawing backend in pixel
     fn get_size(&self) -> (u32, u32);


### PR DESCRIPTION
Without this, collecting errors from other threads (for example when using rayon) will cause compile errors.