### PR TITLE
Adding command to open the generated file in chrome window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Plotters development (?)
+
 ## Plotters 0.2.5 (2019-09-07)
 
 ### Bug Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Plotters development (?)
 
+### Improvement 
+
+- Allowing axis be placed on top or right by setting `right_y_label_area` and `top_x_label_area`
+
 ## Plotters 0.2.5 (2019-09-07)
 
 ### Bug Fix

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -15,6 +15,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut cc = ChartBuilder::on(&upper)
         .x_label_area_size(50)
         .y_label_area_size(60)
+        .top_x_label_area_size(50)
+        .right_y_label_area_size(40)
         .caption("Sine and Cosine", ("Arial", 40).into_font())
         .build_ranged(-3.4f32..3.4f32, -1.2f32..1.2f32)?;
 

--- a/examples/wasm-demo/start-server.sh
+++ b/examples/wasm-demo/start-server.sh
@@ -1,14 +1,25 @@
 #!/bin/bash
 set -e
+
 CONFIG=release
 mkdir -p www/pkg
+
 rustup target add wasm32-unknown-unknown
+
 if [ -z "$(cargo install --list | grep wasm-bindgen-cli)" ]
 then
 	cargo install wasm-bindgen-cli
 fi
-cargo build --target=wasm32-unknown-unknown --release
+
+if [ "${CONFIG}" = "release" ]
+then
+	cargo build --target=wasm32-unknown-unknown --release
+else
+	cargo build --target=wasm32-unknown-unknown --release
+fi
+
 wasm-bindgen --out-dir www/pkg   --target web target/wasm32-unknown-unknown/${CONFIG}/wasm_demo.wasm
 cd www
+
 echo "Goto http://localhost:8000/ to see the result"
 python ../server.py

--- a/examples/wasm-demo/start-server.sh
+++ b/examples/wasm-demo/start-server.sh
@@ -15,7 +15,7 @@ if [ "${CONFIG}" = "release" ]
 then
 	cargo build --target=wasm32-unknown-unknown --release
 else
-	cargo build --target=wasm32-unknown-unknown --release
+	cargo build --target=wasm32-unknown-unknown
 fi
 
 wasm-bindgen --out-dir www/pkg   --target web target/wasm32-unknown-unknown/${CONFIG}/wasm_demo.wasm

--- a/src/chart/builder.rs
+++ b/src/chart/builder.rs
@@ -114,8 +114,8 @@ impl<'a, 'b, DB: DrawingBackend> ChartBuilder<'a, 'b, DB> {
         pixel_range.1 = pixel_range.1.end..pixel_range.1.start;
 
         Ok(ChartContext {
-            x_label_area,
-            y_label_area,
+            x_label_area: [None, x_label_area],
+            y_label_area: [y_label_area, None],
             drawing_area: drawing_area.apply_coord_spec(RangedCoord::new(
                 x_spec,
                 y_spec,

--- a/src/chart/context.rs
+++ b/src/chart/context.rs
@@ -62,8 +62,8 @@ impl<'a, DB: DrawingBackend> SeriesAnno<'a, DB> {
 /// Any plot/chart is abstracted as this type, and any data series can be placed to the chart
 /// context.
 pub struct ChartContext<'a, DB: DrawingBackend, CT: CoordTranslate> {
-    pub(super) x_label_area: Option<DrawingArea<DB, Shift>>,
-    pub(super) y_label_area: Option<DrawingArea<DB, Shift>>,
+    pub(super) x_label_area: [Option<DrawingArea<DB, Shift>>;2],
+    pub(super) y_label_area: [Option<DrawingArea<DB, Shift>>;2],
     pub(super) drawing_area: DrawingArea<DB, CT>,
     pub(super) series_anno: Vec<SeriesAnno<'a, DB>>,
 }
@@ -321,7 +321,7 @@ impl<'a, DB: DrawingBackend, X: Ranged, Y: Ranged> ChartContext<'a, DB, RangedCo
             self.draw_mesh_lines((r, c), (x_mesh, y_mesh), mesh_line_style, fmt_label)?;
 
         self.draw_axis_and_labels(
-            self.x_label_area.as_ref(),
+            self.x_label_area[1].as_ref(),
             if x_axis { Some(axis_style) } else { None },
             &x_labels[..],
             label_style,
@@ -331,7 +331,7 @@ impl<'a, DB: DrawingBackend, X: Ranged, Y: Ranged> ChartContext<'a, DB, RangedCo
         )?;
 
         self.draw_axis_and_labels(
-            self.y_label_area.as_ref(),
+            self.y_label_area[0].as_ref(),
             if y_axis { Some(axis_style) } else { None },
             &y_labels[..],
             label_style,

--- a/src/chart/context.rs
+++ b/src/chart/context.rs
@@ -62,8 +62,8 @@ impl<'a, DB: DrawingBackend> SeriesAnno<'a, DB> {
 /// Any plot/chart is abstracted as this type, and any data series can be placed to the chart
 /// context.
 pub struct ChartContext<'a, DB: DrawingBackend, CT: CoordTranslate> {
-    pub(super) x_label_area: [Option<DrawingArea<DB, Shift>>;2],
-    pub(super) y_label_area: [Option<DrawingArea<DB, Shift>>;2],
+    pub(super) x_label_area: [Option<DrawingArea<DB, Shift>>; 2],
+    pub(super) y_label_area: [Option<DrawingArea<DB, Shift>>; 2],
     pub(super) drawing_area: DrawingArea<DB, CT>,
     pub(super) series_anno: Vec<SeriesAnno<'a, DB>>,
 }
@@ -330,7 +330,7 @@ impl<'a, DB: DrawingBackend, X: Ranged, Y: Ranged> ChartContext<'a, DB, RangedCo
                 (0, -1 + idx as i16 * 2),
                 x_desc.as_ref().map(|desc| (&desc[..], axis_desc_style)),
             )?;
-            
+
             self.draw_axis_and_labels(
                 self.y_label_area[idx].as_ref(),
                 if y_axis { Some(axis_style) } else { None },

--- a/src/chart/context.rs
+++ b/src/chart/context.rs
@@ -320,25 +320,27 @@ impl<'a, DB: DrawingBackend, X: Ranged, Y: Ranged> ChartContext<'a, DB, RangedCo
         let (x_labels, y_labels) =
             self.draw_mesh_lines((r, c), (x_mesh, y_mesh), mesh_line_style, fmt_label)?;
 
-        self.draw_axis_and_labels(
-            self.x_label_area[1].as_ref(),
-            if x_axis { Some(axis_style) } else { None },
-            &x_labels[..],
-            label_style,
-            x_label_offset,
-            (0, 1),
-            x_desc.as_ref().map(|desc| (&desc[..], axis_desc_style)),
-        )?;
-
-        self.draw_axis_and_labels(
-            self.y_label_area[0].as_ref(),
-            if y_axis { Some(axis_style) } else { None },
-            &y_labels[..],
-            label_style,
-            0,
-            (-1, 0),
-            y_desc.as_ref().map(|desc| (&desc[..], axis_desc_style)),
-        )?;
+        for idx in 0..2 {
+            self.draw_axis_and_labels(
+                self.x_label_area[idx].as_ref(),
+                if x_axis { Some(axis_style) } else { None },
+                &x_labels[..],
+                label_style,
+                x_label_offset,
+                (0, -1 + idx as i16 * 2),
+                x_desc.as_ref().map(|desc| (&desc[..], axis_desc_style)),
+            )?;
+            
+            self.draw_axis_and_labels(
+                self.y_label_area[idx].as_ref(),
+                if y_axis { Some(axis_style) } else { None },
+                &y_labels[..],
+                label_style,
+                0,
+                (-1 + idx as i16 * 2, 0),
+                y_desc.as_ref().map(|desc| (&desc[..], axis_desc_style)),
+            )?;
+        }
 
         Ok(())
     }

--- a/src/coord/datetime.rs
+++ b/src/coord/datetime.rs
@@ -67,4 +67,3 @@ impl<Z: TimeZone> super::AsRangedCoord for Range<Date<Z>> {
     type CoordDescType = RangedDate<Z>;
     type Value = Date<Z>;
 }
-

--- a/src/coord/datetime.rs
+++ b/src/coord/datetime.rs
@@ -67,3 +67,4 @@ impl<Z: TimeZone> super::AsRangedCoord for Range<Date<Z>> {
     type CoordDescType = RangedDate<Z>;
     type Value = Date<Z>;
 }
+

--- a/src/coord/numeric.rs
+++ b/src/coord/numeric.rs
@@ -247,6 +247,12 @@ mod test {
 
         assert!(kp.len() > 0);
         assert!(kp.len() <= 28);
+
+        let kp = compute_f64_key_points((-1.2, 1.2), 1);
+        assert!(kp.len() == 1);
+        
+        let kp = compute_f64_key_points((-1.2, 1.2), 0);
+        assert!(kp.len() == 0);
     }
 
     #[test]

--- a/src/coord/numeric.rs
+++ b/src/coord/numeric.rs
@@ -250,7 +250,7 @@ mod test {
 
         let kp = compute_f64_key_points((-1.2, 1.2), 1);
         assert!(kp.len() == 1);
-        
+
         let kp = compute_f64_key_points((-1.2, 1.2), 0);
         assert!(kp.len() == 0);
     }


### PR DESCRIPTION
As we can open the generated drawing using google chrome from command line as below
```bash
C:\Users\hasan.DESKTOP-HU2FQ29\PycharmProjects\rust>start chrome --new-window --app="file:///%cd%/0.png" --incognito --disable-extensions --window-size="640, 640"
```

Where:
- `start chrome` opens google chrome in Windows 10, in Mac it can be replaced by `/Applications/Google\ Chrome.app/Contents/MacOS/Google\` and in Linix it can be replaced by: `google-chrome`

- `--new-window` to open new chrome instant
- `--app` to remove the toolbar
- `%cd%` to get the current path in Windows 10, in Mac and Linux, I think it is `pwd`
- `--incognito` to open in incognito mode
- `--disable-extensions` to disable all extensions
- `--window-size="640, 640"` windows size to match drawing size

I run the above, and got the below:

![image](https://user-images.githubusercontent.com/46838626/64622890-b1328280-d3f0-11e9-9355-ade3bc1ff270.png)
