### PR TITLE
Allow for custom svg

### DIFF
--- a/src/drawing/backend_impl/mod.rs
+++ b/src/drawing/backend_impl/mod.rs
@@ -2,6 +2,8 @@
 mod svg;
 #[cfg(feature = "svg")]
 pub use self::svg::SVGBackend;
+#[cfg(feature = "svg")]
+pub use ::svg as svg_types;
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "image"))]
 mod bitmap;

--- a/src/drawing/backend_impl/svg.rs
+++ b/src/drawing/backend_impl/svg.rs
@@ -34,7 +34,7 @@ pub struct SVGBackend<'a> {
 }
 
 impl<'a> SVGBackend<'a> {
-    fn update_document<F: FnOnce(Document) -> Document>(&mut self, op: F) {
+    pub fn update_document<F: FnOnce(Document) -> Document>(&mut self, op: F) {
         let mut temp = None;
         std::mem::swap(&mut temp, &mut self.document);
         self.document = Some(op(temp.unwrap()));


### PR DESCRIPTION
This allows adding custom svg to a document. Opening mainly for discussion.

The svg create is currently reexported, since this now exposes svg types directly from the api and we avoid version hell, be allowing users to use our version. This change should be done with care, since version bumps of svg with breaking changes are also breaking api changes.