### PR TITLE
Change FontLoadError from Rc to Arc for Send

### DIFF
--- a/src/style/font/ttf.rs
+++ b/src/style/font/ttf.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::i32;
 use std::marker::PhantomPinned;
 use std::pin::Pin;
-use std::rc::Rc;
 use std::slice::from_raw_parts;
+use std::sync::Arc;
 use std::sync::Mutex;
 
 use rusttype::{point, Error, Font, Scale};
@@ -20,7 +20,7 @@ type FontResult<T> = Result<T, FontError>;
 pub enum FontError {
     LockError,
     NoSuchFont,
-    FontLoadError(Rc<Error>),
+    FontLoadError(Arc<Error>),
 }
 
 impl std::fmt::Display for FontError {
@@ -89,7 +89,7 @@ fn load_font_data(face: &str) -> FontResult<&'static Font<'static>> {
                 .build();
             if let Some((data, _)) = system_fonts::get(&query) {
                 let font =
-                    OwnedFont::new(data).map_err(|e| FontError::FontLoadError(Rc::new(e)))?;
+                    OwnedFont::new(data).map_err(|e| FontError::FontLoadError(Arc::new(e)))?;
                 cache.insert(face.to_string(), font);
             } else {
                 return Err(FontError::NoSuchFont);


### PR DESCRIPTION
I tried to convert from `DrawingAreaErrorKind<DB::ErrorType>` to `failure::Error`, and failed.

```
error[E0277]: `std::rc::Rc<rusttype::Error>` cannot be shared between threads safely
  --> src/plotter.rs:77:54
   |
77 |             .build_ranged(x_min..x_max, y_min..y_max)?;
   |                                                      ^ `std::rc::Rc<rusttype::Error>` cannot be shared between threads safely
   |
   = help: within `plotters::drawing::area::DrawingAreaErrorKind<<T as plotters::drawing::backend::DrawingBackend>::ErrorType>`, the trait `std::marker::Sync` is not implemented for `std::rc::Rc<rusttype::Error>`
   = note: required because it appears within the type `plotters::style::font::ttf::FontError`
   = note: required because it appears within the type `plotters::drawing::backend::DrawingErrorKind<<T as plotters::drawing::backend::DrawingBackend>::ErrorType>`
   = note: required because it appears within the type `plotters::drawing::area::DrawingAreaErrorKind<<T as plotters::drawing::backend::DrawingBackend>::ErrorType>`
   = note: required because of the requirements on the impl of `failure::Fail` for `plotters::drawing::area::DrawingAreaErrorKind<<T as plotters::drawing::backend::DrawingBackend>::ErrorType>`
   = note: required because of the requirements on the impl of `std::convert::From<plotters::drawing::area::DrawingAreaErrorKind<<T as plotters::drawing::backend::DrawingBackend>::ErrorType>>` for `failure::error::Error`
   = note: required by `std::convert::From::from`
```

This seems to be caused by `FontLoadError(Rc<Error>)`.
If `Rc` can be changed to `Arc`, the error will be fixed.