### PR TITLE
Refactor font cache

### DIFF
--- a/src/chart/builder.rs
+++ b/src/chart/builder.rs
@@ -320,14 +320,17 @@ mod test {
         let drawing_area = create_mocked_drawing_area(200, 200, |_| {});
         let mut chart = ChartBuilder::on(&drawing_area);
 
-        chart.caption("This is a test case", ("oblique", 10));
+        chart.caption("This is a test case", (FontFamily::Sans, 10));
 
         assert_eq!(chart.title.as_ref().unwrap().0, "This is a test case");
-        assert_eq!(chart.title.as_ref().unwrap().1.font.get_name(), "oblique");
+        assert_eq!(chart.title.as_ref().unwrap().1.font.get_name(), "sans");
         assert_eq!(chart.title.as_ref().unwrap().1.font.get_size(), 10.0);
         assert_eq!(
             chart.title.as_ref().unwrap().1.color.to_rgba(),
             BLACK.to_rgba()
         );
+
+        chart.caption("This is a test case", ("sans", 10));
+        assert_eq!(chart.title.as_ref().unwrap().1.font.get_name(), "sans");
     }
 }

--- a/src/chart/builder.rs
+++ b/src/chart/builder.rs
@@ -320,10 +320,10 @@ mod test {
         let drawing_area = create_mocked_drawing_area(200, 200, |_| {});
         let mut chart = ChartBuilder::on(&drawing_area);
 
-        chart.caption("This is a test case", ("Arial", 10));
+        chart.caption("This is a test case", ("oblique", 10));
 
         assert_eq!(chart.title.as_ref().unwrap().0, "This is a test case");
-        assert_eq!(chart.title.as_ref().unwrap().1.font.get_name(), "Arial");
+        assert_eq!(chart.title.as_ref().unwrap().1.font.get_name(), "oblique");
         assert_eq!(chart.title.as_ref().unwrap().1.font.get_size(), 10.0);
         assert_eq!(
             chart.title.as_ref().unwrap().1.color.to_rgba(),

--- a/src/chart/context.rs
+++ b/src/chart/context.rs
@@ -597,7 +597,7 @@ mod test {
         drawing_area.fill(&WHITE).expect("Fill");
 
         let mut chart = ChartBuilder::on(&drawing_area)
-            .caption("Test Title", ("oblique", 10))
+            .caption("Test Title", ("sans", 10))
             .x_label_area_size(20)
             .y_label_area_size(20)
             .set_label_area_size(LabelAreaPosition::Top, 20)

--- a/src/chart/context.rs
+++ b/src/chart/context.rs
@@ -597,7 +597,7 @@ mod test {
         drawing_area.fill(&WHITE).expect("Fill");
 
         let mut chart = ChartBuilder::on(&drawing_area)
-            .caption("Test Title", ("Arial", 10))
+            .caption("Test Title", ("oblique", 10))
             .x_label_area_size(20)
             .y_label_area_size(20)
             .set_label_area_size(LabelAreaPosition::Top, 20)

--- a/src/chart/mesh.rs
+++ b/src/chart/mesh.rs
@@ -329,7 +329,7 @@ where
         let default_mesh_color_2 = RGBColor(0, 0, 0).mix(0.1);
         let default_axis_color = RGBColor(0, 0, 0);
         let default_label_font = FontDesc::new(
-            "Arial",
+            "oblique",
             f64::from((12i32).percent().max(12).in_pixels(&self.parent_size)),
         );
 

--- a/src/chart/mesh.rs
+++ b/src/chart/mesh.rs
@@ -7,7 +7,8 @@ use crate::coord::{MeshLine, Ranged, RangedCoord};
 use crate::drawing::backend::DrawingBackend;
 use crate::drawing::DrawingAreaErrorKind;
 use crate::style::{
-    AsRelative, Color, FontDesc, IntoTextStyle, RGBColor, ShapeStyle, SizeDesc, TextStyle,
+    AsRelative, Color, FontDesc, FontFamily, IntoTextStyle, RGBColor, ShapeStyle, SizeDesc,
+    TextStyle,
 };
 
 /// The style used to describe the mesh for a secondary coordinate system.
@@ -329,7 +330,7 @@ where
         let default_mesh_color_2 = RGBColor(0, 0, 0).mix(0.1);
         let default_axis_color = RGBColor(0, 0, 0);
         let default_label_font = FontDesc::new(
-            "oblique",
+            FontFamily::Sans,
             f64::from((12i32).percent().max(12).in_pixels(&self.parent_size)),
         );
 

--- a/src/chart/series.rs
+++ b/src/chart/series.rs
@@ -114,7 +114,7 @@ impl<'a, 'b, DB: DrawingBackend + 'a, CT: CoordTranslate> SeriesLabelStyle<'a, '
     /// Draw the series label area
     pub fn draw(&mut self) -> Result<(), DrawingAreaErrorKind<DB::ErrorType>> {
         let drawing_area = self.target.plotting_area().strip_coord_spec();
-        let default_font = ("oblique", 12).into_font();
+        let default_font = ("sans", 12).into_font();
         let default_style: TextStyle = default_font.into();
 
         let font = {

--- a/src/chart/series.rs
+++ b/src/chart/series.rs
@@ -114,7 +114,7 @@ impl<'a, 'b, DB: DrawingBackend + 'a, CT: CoordTranslate> SeriesLabelStyle<'a, '
     /// Draw the series label area
     pub fn draw(&mut self) -> Result<(), DrawingAreaErrorKind<DB::ErrorType>> {
         let drawing_area = self.target.plotting_area().strip_coord_spec();
-        let default_font = ("Arial", 12).into_font();
+        let default_font = ("oblique", 12).into_font();
         let default_style: TextStyle = default_font.into();
 
         let font = {

--- a/src/drawing/area.rs
+++ b/src/drawing/area.rs
@@ -690,7 +690,7 @@ mod drawing_area_tests {
         let drawing_area = create_mocked_drawing_area(1024, 768, |m| {
             m.check_draw_text(|c, font, size, _pos, text| {
                 assert_eq!(c, BLACK.to_rgba());
-                assert_eq!(font, "Arial");
+                assert_eq!(font, "oblique");
                 assert_eq!(size, 30.0);
                 assert_eq!("This is the title", text);
             });
@@ -709,7 +709,7 @@ mod drawing_area_tests {
         });
 
         drawing_area
-            .titled("This is the title", ("Arial", 30))
+            .titled("This is the title", ("oblique", 30))
             .unwrap()
             .fill(&WHITE)
             .unwrap();

--- a/src/drawing/area.rs
+++ b/src/drawing/area.rs
@@ -690,7 +690,7 @@ mod drawing_area_tests {
         let drawing_area = create_mocked_drawing_area(1024, 768, |m| {
             m.check_draw_text(|c, font, size, _pos, text| {
                 assert_eq!(c, BLACK.to_rgba());
-                assert_eq!(font, "oblique");
+                assert_eq!(font, "sans");
                 assert_eq!(size, 30.0);
                 assert_eq!("This is the title", text);
             });
@@ -709,7 +709,7 @@ mod drawing_area_tests {
         });
 
         drawing_area
-            .titled("This is the title", ("oblique", 30))
+            .titled("This is the title", ("sans", 30))
             .unwrap()
             .fill(&WHITE)
             .unwrap();

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -46,7 +46,7 @@
         ) -> Result<(), DrawingErrorKind<DB::ErrorType>> {
             let pos = pos.next().unwrap();
             backend.draw_rect(pos, (pos.0 + 10, pos.1 + 12), &RED.to_rgba(), false)?;
-            backend.draw_text("X", &("oblique", 20).into(), pos, &RED.to_rgba())
+            backend.draw_text("X", &("sans", 20).into(), pos, &RED.to_rgba())
         }
     }
 
@@ -76,9 +76,9 @@
             "plotters-doc-data/element-1.png",
             (640, 480)
         ).into_drawing_area();
-        let font:FontDesc = ("oblique", 20).into();
+        let font:FontDesc = ("sans", 20).into();
         root.draw(&(EmptyElement::at((200, 200))
-                + Text::new("X", (0, 0), &"oblique".into_font().resize(20.0).color(&RED))
+                + Text::new("X", (0, 0), &"sans".into_font().resize(20.0).color(&RED))
                 + Rectangle::new([(0,0), (10, 12)], &RED)
         ))?;
         Ok(())

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -46,7 +46,7 @@
         ) -> Result<(), DrawingErrorKind<DB::ErrorType>> {
             let pos = pos.next().unwrap();
             backend.draw_rect(pos, (pos.0 + 10, pos.1 + 12), &RED.to_rgba(), false)?;
-            backend.draw_text("X", &("Arial", 20).into(), pos, &RED.to_rgba())
+            backend.draw_text("X", &("oblique", 20).into(), pos, &RED.to_rgba())
         }
     }
 
@@ -76,9 +76,9 @@
             "plotters-doc-data/element-1.png",
             (640, 480)
         ).into_drawing_area();
-        let font:FontDesc = ("Arial", 20).into();
+        let font:FontDesc = ("oblique", 20).into();
         root.draw(&(EmptyElement::at((200, 200))
-                + Text::new("X", (0, 0), &"Arial".into_font().resize(20.0).color(&RED))
+                + Text::new("X", (0, 0), &"oblique".into_font().resize(20.0).color(&RED))
                 + Rectangle::new([(0,0), (10, 12)], &RED)
         ))?;
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,7 +265,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let root = BitMapBackend::new("plotters-doc-data/0.png", (640, 480)).into_drawing_area();
     root.fill(&WHITE)?;
     let mut chart = ChartBuilder::on(&root)
-        .caption("y=x^2", ("Arial", 50).into_font())
+        .caption("y=x^2", ("oblique", 50).into_font())
         .margin(5)
         .x_label_area_size(30)
         .y_label_area_size(30)
@@ -309,7 +309,7 @@ use plotters::prelude::*;
 let figure = evcxr_figure((640, 480), |root| {
     root.fill(&WHITE);
     let mut chart = ChartBuilder::on(&root)
-        .caption("y=x^2", ("Arial", 50).into_font())
+        .caption("y=x^2", ("oblique", 50).into_font())
         .margin(5)
         .x_label_area_size(30)
         .y_label_area_size(30)
@@ -492,7 +492,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             + Text::new(
                 format!("({:.2},{:.2})", x, y),
                 (10, 0),
-                ("Arial", 15.0).into_font(),
+                ("oblique", 15.0).into_font(),
             );
     };
 
@@ -521,7 +521,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // After this point, we should be able to draw construct a chart context
     let mut chart = ChartBuilder::on(&root)
         // Set the caption of the chart
-        .caption("This is our first plot", ("Arial", 40).into_font())
+        .caption("This is our first plot", ("oblique", 40).into_font())
         // Set the size of the label region
         .x_label_area_size(20)
         .y_label_area_size(40)
@@ -551,7 +551,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &|c, s, st| {
             return EmptyElement::at(c)    // We want to construct a composed element on-the-fly
             + Circle::new((0,0),s,st.filled()) // At this point, the new pixel coordinate is established
-            + Text::new(format!("{:?}", c), (10, 0), ("Arial", 10).into_font());
+            + Text::new(format!("{:?}", c), (10, 0), ("oblique", 10).into_font());
         },
     ))?;
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,7 +265,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let root = BitMapBackend::new("plotters-doc-data/0.png", (640, 480)).into_drawing_area();
     root.fill(&WHITE)?;
     let mut chart = ChartBuilder::on(&root)
-        .caption("y=x^2", ("oblique", 50).into_font())
+        .caption("y=x^2", ("sans", 50).into_font())
         .margin(5)
         .x_label_area_size(30)
         .y_label_area_size(30)
@@ -309,7 +309,7 @@ use plotters::prelude::*;
 let figure = evcxr_figure((640, 480), |root| {
     root.fill(&WHITE);
     let mut chart = ChartBuilder::on(&root)
-        .caption("y=x^2", ("oblique", 50).into_font())
+        .caption("y=x^2", ("sans", 50).into_font())
         .margin(5)
         .x_label_area_size(30)
         .y_label_area_size(30)
@@ -492,7 +492,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             + Text::new(
                 format!("({:.2},{:.2})", x, y),
                 (10, 0),
-                ("oblique", 15.0).into_font(),
+                ("sans", 15.0).into_font(),
             );
     };
 
@@ -521,7 +521,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // After this point, we should be able to draw construct a chart context
     let mut chart = ChartBuilder::on(&root)
         // Set the caption of the chart
-        .caption("This is our first plot", ("oblique", 40).into_font())
+        .caption("This is our first plot", ("sans", 40).into_font())
         // Set the size of the label region
         .x_label_area_size(20)
         .y_label_area_size(40)
@@ -551,7 +551,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &|c, s, st| {
             return EmptyElement::at(c)    // We want to construct a composed element on-the-fly
             + Circle::new((0,0),s,st.filled()) // At this point, the new pixel coordinate is established
-            + Text::new(format!("{:?}", c), (10, 0), ("oblique", 10).into_font());
+            + Text::new(format!("{:?}", c), (10, 0), ("sans", 10).into_font());
         },
     ))?;
     Ok(())
@@ -673,8 +673,9 @@ pub mod prelude {
     pub use crate::drawing::*;
     pub use crate::series::{AreaSeries, Histogram, LineSeries, PointSeries};
     pub use crate::style::{
-        AsRelative, Color, FontDesc, FontTransform, HSLColor, IntoFont, Palette, Palette100,
-        Palette99, Palette9999, PaletteColor, RGBColor, ShapeStyle, SimpleColor, TextStyle,
+        AsRelative, Color, FontDesc, FontFamily, FontTransform, HSLColor, IntoFont, Palette,
+        Palette100, Palette99, Palette9999, PaletteColor, RGBColor, ShapeStyle, SimpleColor,
+        TextStyle,
     };
     pub use crate::style::{BLACK, BLUE, CYAN, GREEN, MAGENTA, RED, TRANSPARENT, WHITE, YELLOW};
 

--- a/src/style/font/font_desc.rs
+++ b/src/style/font/font_desc.rs
@@ -45,20 +45,63 @@ impl FontTransform {
 #[derive(Clone)]
 pub struct FontDesc<'a> {
     size: f64,
-    name: &'a str,
+    family: FontFamily<'a>,
     data: FontResult<FontDataInternal>,
     transform: FontTransform,
 }
 
+/// Describes font family
+#[derive(Clone, Copy)]
+pub enum FontFamily<'a> {
+    Sans,
+    SansSerif,
+    Monospace,
+    Name(&'a str),
+}
+
+impl<'a> FontFamily<'a> {
+    pub fn as_str(&self) -> &str {
+        match self {
+            FontFamily::Sans => "sans",
+            FontFamily::SansSerif => "sans-serif",
+            FontFamily::Monospace => "monospace",
+            FontFamily::Name(face) => face,
+        }
+    }
+}
+
+impl<'a> From<&'a str> for FontFamily<'a> {
+    fn from(from: &'a str) -> FontFamily<'a> {
+        match from {
+            "sans" => FontFamily::Sans,
+            "sans-serif" => FontFamily::SansSerif,
+            "monospace" => FontFamily::Monospace,
+            _ => FontFamily::Name(from),
+        }
+    }
+}
+
 impl<'a> From<&'a str> for FontDesc<'a> {
     fn from(from: &'a str) -> FontDesc<'a> {
-        FontDesc::new(from, 1.0)
+        FontDesc::new(from.into(), 1.0)
+    }
+}
+
+impl<'a> From<FontFamily<'a>> for FontDesc<'a> {
+    fn from(family: FontFamily<'a>) -> FontDesc<'a> {
+        FontDesc::new(family, 1.0)
+    }
+}
+
+impl<'a, T: Into<f64>> From<(FontFamily<'a>, T)> for FontDesc<'a> {
+    fn from((family, size): (FontFamily<'a>, T)) -> FontDesc<'a> {
+        FontDesc::new(family, size.into())
     }
 }
 
 impl<'a, T: Into<f64>> From<(&'a str, T)> for FontDesc<'a> {
     fn from((typeface, size): (&'a str, T)) -> FontDesc<'a> {
-        FontDesc::new(typeface, size.into())
+        FontDesc::new(typeface.into(), size.into())
     }
 }
 
@@ -74,11 +117,11 @@ impl<'a, T: Into<FontDesc<'a>>> IntoFont<'a> for T {
 
 impl<'a> FontDesc<'a> {
     /// Create a new font
-    pub fn new(typeface: &'a str, size: f64) -> Self {
+    pub fn new(family: FontFamily<'a>, size: f64) -> Self {
         Self {
             size,
-            name: typeface,
-            data: FontDataInternal::new(typeface),
+            family,
+            data: FontDataInternal::new(family),
             transform: FontTransform::None,
         }
     }
@@ -87,7 +130,7 @@ impl<'a> FontDesc<'a> {
     pub fn resize(&self, size: f64) -> FontDesc<'a> {
         Self {
             size,
-            name: self.name,
+            family: self.family,
             data: self.data.clone(),
             transform: self.transform.clone(),
         }
@@ -97,7 +140,7 @@ impl<'a> FontDesc<'a> {
     pub fn transform(&self, trans: FontTransform) -> Self {
         Self {
             size: self.size,
-            name: self.name,
+            family: self.family,
             data: self.data.clone(),
             transform: trans,
         }
@@ -117,8 +160,8 @@ impl<'a> FontDesc<'a> {
     }
 
     /// Get the name of the font
-    pub fn get_name(&self) -> &'a str {
-        self.name
+    pub fn get_name(&self) -> &str {
+        self.family.as_str()
     }
 
     /// Get the size of font

--- a/src/style/font/mod.rs
+++ b/src/style/font/mod.rs
@@ -25,7 +25,7 @@ pub type LayoutBox = ((i32, i32), (i32, i32));
 
 pub trait FontData: Clone {
     type ErrorType: Sized + std::error::Error + Clone;
-    fn new(face: &str) -> Result<Self, Self::ErrorType>;
+    fn new(family: FontFamily) -> Result<Self, Self::ErrorType>;
     fn estimate_layout(&self, size: f64, text: &str) -> Result<LayoutBox, Self::ErrorType>;
     fn draw<E, DrawFunc: FnMut(i32, i32, f32) -> Result<(), E>>(
         &self,

--- a/src/style/font/ttf.rs
+++ b/src/style/font/ttf.rs
@@ -1,14 +1,9 @@
 use std::collections::HashMap;
 use std::i32;
-use std::marker::PhantomPinned;
-use std::pin::Pin;
-use std::slice::from_raw_parts;
-use std::sync::Arc;
-use std::sync::Mutex;
-
-use rusttype::{point, Error, Font, Scale};
+use std::sync::{Arc, Mutex};
 
 use lazy_static::lazy_static;
+use rusttype::{point, Error, Font, Scale, SharedBytes};
 
 use font_loader::system_fonts::{self, FontPropertyBuilder};
 
@@ -35,86 +30,40 @@ impl std::fmt::Display for FontError {
 
 impl std::error::Error for FontError {}
 
-struct OwnedFont {
-    data: Vec<u8>,
-    font: Option<Font<'static>>,
-    _pinned: PhantomPinned,
-}
-
-impl OwnedFont {
-    fn new(data: Vec<u8>) -> Result<Pin<Box<Self>>, Error> {
-        let font_obj = OwnedFont {
-            data,
-            font: None,
-            _pinned: PhantomPinned,
-        };
-
-        let mut boxed_font_obj = Box::pin(font_obj);
-
-        unsafe {
-            let addr = &boxed_font_obj.data[0] as *const u8;
-            let font = Font::from_bytes(from_raw_parts(addr, boxed_font_obj.data.len()))?;
-            let mut_ref: Pin<&mut Self> = Pin::as_mut(&mut boxed_font_obj);
-            Pin::get_unchecked_mut(mut_ref).font =
-                std::mem::transmute::<_, Option<Font<'static>>>(Some(font));
-        }
-
-        Ok(boxed_font_obj)
-    }
-}
-
-impl Drop for OwnedFont {
-    fn drop(&mut self) {
-        self.font = None;
-    }
-}
-
-impl<'a> Into<&'a Font<'a>> for &'a OwnedFont {
-    fn into(self) -> &'a Font<'a> {
-        self.font.as_ref().unwrap()
-    }
-}
-
 lazy_static! {
-    static ref FONT_DATA_CACHE: Mutex<HashMap<String, Pin<Box<OwnedFont>>>> =
-        { Mutex::new(HashMap::new()) };
+    static ref CACHE: Mutex<HashMap<String, Option<SharedBytes<'static>>>> =
+        Mutex::new(HashMap::new());
 }
 
 #[allow(dead_code)]
-fn load_font_data(face: &str) -> FontResult<&'static Font<'static>> {
-    match FONT_DATA_CACHE.lock().map(|mut cache| {
-        if !cache.contains_key(face) {
+/// Lazily load font data. Font type doesn't own actual data, which
+/// lives in the cache.
+fn load_font_data(face: &str) -> FontResult<Font<'static>> {
+    CACHE
+        .lock()
+        .map_err(|_| FontError::LockError)?
+        .entry(face.into())
+        .or_insert_with(|| {
             let query = FontPropertyBuilder::new().family(face).build();
-            if let Some((data, _)) = system_fonts::get(&query) {
-                let font =
-                    OwnedFont::new(data).map_err(|e| FontError::FontLoadError(Arc::new(e)))?;
-                cache.insert(face.to_string(), font);
-            } else {
-                return Err(FontError::NoSuchFont);
-            }
-        }
-        let font_ref: &'static OwnedFont =
-            unsafe { std::mem::transmute(cache.get(face).unwrap().as_ref().get_ref()) };
-        let addr = Into::<&'static Font<'static>>::into(font_ref) as *const Font<'static>;
-        Ok(unsafe { addr.as_ref().unwrap() })
-    }) {
-        Ok(what) => what,
-        Err(_) => Err(FontError::LockError),
-    }
+            system_fonts::get(&query).map(|(data, _)| data.into())
+        })
+        .clone()
+        .ok_or(FontError::NoSuchFont)
+        .and_then(|cached| {
+            Font::from_bytes(cached).map_err(|err| FontError::FontLoadError(Arc::new(err)))
+        })
 }
 
-/// STOP! This is generally a bad idea, because all the font we borrowed out should have a static life
-/// time, thus clear the font cache may cause problem.
+/// Remove all cached fonts data.
 #[allow(dead_code)]
-pub unsafe fn clear_font_cache() -> FontResult<()> {
-    if let Ok(mut cache) = FONT_DATA_CACHE.lock() {
-        *cache = HashMap::new();
-    }
-    Err(FontError::LockError)
+pub fn clear_font_cache() -> FontResult<()> {
+    let mut cache = CACHE.lock().map_err(|_| FontError::LockError)?;
+    cache.clear();
+    Ok(())
 }
 
 #[derive(Clone)]
-pub struct FontDataInternal(&'static Font<'static>);
+pub struct FontDataInternal(Font<'static>);
 
 impl FontData for FontDataInternal {
     type ErrorType = FontError;
@@ -129,7 +78,7 @@ impl FontData for FontDataInternal {
         let (mut min_x, mut min_y) = (i32::MAX, i32::MAX);
         let (mut max_x, mut max_y) = (0, 0);
 
-        let font = self.0;
+        let font = &self.0;
 
         font.layout(text, scale, point(0.0, 0.0)).for_each(|g| {
             if let Some(rect) = g.pixel_bounding_box() {
@@ -160,7 +109,7 @@ impl FontData for FontDataInternal {
 
         let scale = Scale::uniform(size as f32);
         let mut result = Ok(());
-        let font = self.0;
+        let font = &self.0;
 
         let base_x = x + trans.offset(layout).0;
         let base_y = y + trans.offset(layout).1;
@@ -188,10 +137,15 @@ mod test {
 
     #[test]
     fn test_font_cache() -> FontResult<()> {
-        let font1 = load_font_data("sans")?;
-        let font2 = load_font_data("sans")?;
+        clear_font_cache()?;
 
-        assert_eq!(font1 as *const Font<'static>, font2 as *const Font<'static>);
+        assert_eq!(CACHE.lock().unwrap().len(), 0);
+
+        load_font_data("sans")?;
+        assert_eq!(CACHE.lock().unwrap().len(), 1);
+
+        load_font_data("sans")?;
+        assert_eq!(CACHE.lock().unwrap().len(), 1);
 
         return Ok(());
     }

--- a/src/style/font/ttf.rs
+++ b/src/style/font/ttf.rs
@@ -5,12 +5,13 @@ use std::pin::Pin;
 use std::slice::from_raw_parts;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::borrow::Cow;
 
 use rusttype::{point, Error, Font, Scale};
 
 use lazy_static::lazy_static;
 
-use font_loader::system_fonts;
+use font_loader::system_fonts::{self, FontPropertyBuilder};
 
 use super::{FontData, FontTransform, LayoutBox};
 
@@ -84,9 +85,7 @@ lazy_static! {
 fn load_font_data(face: &str) -> FontResult<&'static Font<'static>> {
     match FONT_DATA_CACHE.lock().map(|mut cache| {
         if !cache.contains_key(face) {
-            let query = system_fonts::FontPropertyBuilder::new()
-                .family(face)
-                .build();
+            let query = FontPropertyBuilder::new().family(&find_typefamily(face)).build();
             if let Some((data, _)) = system_fonts::get(&query) {
                 let font =
                     OwnedFont::new(data).map_err(|e| FontError::FontLoadError(Arc::new(e)))?;
@@ -104,6 +103,28 @@ fn load_font_data(face: &str) -> FontResult<&'static Font<'static>> {
         Err(_) => Err(FontError::LockError),
     }
 }
+
+/// Find typefamily based on requested face.
+fn find_typefamily(face: &str) -> Cow<str> {
+    let family = match face.to_lowercase().as_str() {
+        "italic" => query_typefamily(FontPropertyBuilder::new().italic()),
+        "oblique" => query_typefamily(FontPropertyBuilder::new().oblique()),
+        "bold" => query_typefamily(FontPropertyBuilder::new().bold()),
+        "monospace" => query_typefamily(FontPropertyBuilder::new().monospace()),
+        _ => None,
+    };
+    if let Some(family) = family {
+        Cow::from(family)
+    } else {
+        Cow::from(face)
+    }
+}
+
+fn query_typefamily(query: FontPropertyBuilder) -> Option<String> {
+    let mut query = query.build();
+    system_fonts::query_specific(&mut query).into_iter().next()
+}
+
 
 /// STOP! This is generally a bad idea, because all the font we borrowed out should have a static life
 /// time, thus clear the font cache may cause problem.
@@ -187,8 +208,8 @@ mod test {
 
     #[test]
     fn test_font_cache() -> FontResult<()> {
-        let font1 = load_font_data("Arial")?;
-        let font2 = load_font_data("Arial")?;
+        let font1 = load_font_data("oblique")?;
+        let font2 = load_font_data("oblique")?;
 
         assert_eq!(font1 as *const Font<'static>, font2 as *const Font<'static>);
 

--- a/src/style/font/web.rs
+++ b/src/style/font/web.rs
@@ -1,4 +1,4 @@
-use super::{FontData, LayoutBox};
+use super::{FontData, FontFamily, LayoutBox};
 use wasm_bindgen::JsCast;
 use web_sys::{window, HtmlElement};
 
@@ -22,8 +22,8 @@ pub struct FontDataInternal(String);
 
 impl FontData for FontDataInternal {
     type ErrorType = FontError;
-    fn new(face: &str) -> Result<Self, FontError> {
-        Ok(FontDataInternal(face.to_string()))
+    fn new(family: FontFamily) -> Result<Self, FontError> {
+        Ok(FontDataInternal(family.as_str().into()))
     }
     fn estimate_layout(&self, size: f64, text: &str) -> Result<LayoutBox, Self::ErrorType> {
         let window = window().unwrap();

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -16,7 +16,7 @@ mod palette_ext;
 pub use self::palette::*;
 pub use color::{Color, HSLColor, PaletteColor, RGBAColor, RGBColor, SimpleColor};
 pub use colors::{BLACK, BLUE, CYAN, GREEN, MAGENTA, RED, TRANSPARENT, WHITE, YELLOW};
-pub use font::{FontDesc, FontError, FontResult, FontTransform, IntoFont, LayoutBox};
+pub use font::{FontDesc, FontError, FontFamily, FontResult, FontTransform, IntoFont, LayoutBox};
 pub use shape::ShapeStyle;
 pub use size::{AsRelative, RelativeSize, SizeDesc};
 pub use text::{IntoTextStyle, TextStyle};

--- a/src/style/text.rs
+++ b/src/style/text.rs
@@ -1,5 +1,5 @@
 use super::color::{Color, RGBAColor};
-use super::font::{FontDesc, FontTransform};
+use super::font::{FontDesc, FontFamily, FontTransform};
 use super::size::{HasDimension, SizeDesc};
 use super::BLACK;
 
@@ -26,7 +26,19 @@ impl<'a> IntoTextStyle<'a> for TextStyle<'a> {
     }
 }
 
+impl<'a> IntoTextStyle<'a> for FontFamily<'a> {
+    fn into_text_style<P: HasDimension>(self, _: &P) -> TextStyle<'a> {
+        self.into()
+    }
+}
+
 impl<'a, T: SizeDesc> IntoTextStyle<'a> for (&'a str, T) {
+    fn into_text_style<P: HasDimension>(self, parent: &P) -> TextStyle<'a> {
+        (self.0, self.1.in_pixels(parent)).into()
+    }
+}
+
+impl<'a, T: SizeDesc> IntoTextStyle<'a> for (FontFamily<'a>, T) {
     fn into_text_style<P: HasDimension>(self, parent: &P) -> TextStyle<'a> {
         (self.0, self.1.in_pixels(parent)).into()
     }


### PR DESCRIPTION
This change greatly simplifies font caching and removes unsafe
code. It shouldn't affect any functionality. Performance should be
comparable, but of course benchmarks should be run to check that.

NOTE: This commit PR is based on #63 and should be rebased after original one will be merged or rejected.
