### PR TITLE
Replace FontDesc name with new FontFamily type

### DIFF
--- a/src/chart/builder.rs
+++ b/src/chart/builder.rs
@@ -320,14 +320,18 @@ mod test {
         let drawing_area = create_mocked_drawing_area(200, 200, |_| {});
         let mut chart = ChartBuilder::on(&drawing_area);
 
-        chart.caption("This is a test case", ("Arial", 10));
+
+        chart.caption("This is a test case", (FontFamily::Serif, 10));
 
         assert_eq!(chart.title.as_ref().unwrap().0, "This is a test case");
-        assert_eq!(chart.title.as_ref().unwrap().1.font.get_name(), "Arial");
+        assert_eq!(chart.title.as_ref().unwrap().1.font.get_name(), "serif");
         assert_eq!(chart.title.as_ref().unwrap().1.font.get_size(), 10.0);
         assert_eq!(
             chart.title.as_ref().unwrap().1.color.to_rgba(),
             BLACK.to_rgba()
         );
+
+        chart.caption("This is a test case", ("serif", 10));
+        assert_eq!(chart.title.as_ref().unwrap().1.font.get_name(), "serif");
     }
 }

--- a/src/chart/context.rs
+++ b/src/chart/context.rs
@@ -597,7 +597,7 @@ mod test {
         drawing_area.fill(&WHITE).expect("Fill");
 
         let mut chart = ChartBuilder::on(&drawing_area)
-            .caption("Test Title", ("Arial", 10))
+            .caption("Test Title", ("serif", 10))
             .x_label_area_size(20)
             .y_label_area_size(20)
             .set_label_area_size(LabelAreaPosition::Top, 20)

--- a/src/chart/mesh.rs
+++ b/src/chart/mesh.rs
@@ -7,7 +7,8 @@ use crate::coord::{MeshLine, Ranged, RangedCoord};
 use crate::drawing::backend::DrawingBackend;
 use crate::drawing::DrawingAreaErrorKind;
 use crate::style::{
-    AsRelative, Color, FontDesc, IntoTextStyle, RGBColor, ShapeStyle, SizeDesc, TextStyle,
+    AsRelative, Color, FontDesc, FontFamily, IntoTextStyle, RGBColor, ShapeStyle, SizeDesc,
+    TextStyle,
 };
 
 /// The style used to describe the mesh for a secondary coordinate system.
@@ -329,7 +330,7 @@ where
         let default_mesh_color_2 = RGBColor(0, 0, 0).mix(0.1);
         let default_axis_color = RGBColor(0, 0, 0);
         let default_label_font = FontDesc::new(
-            "Arial",
+            FontFamily::Serif,
             f64::from((12i32).percent().max(12).in_pixels(&self.parent_size)),
         );
 

--- a/src/chart/series.rs
+++ b/src/chart/series.rs
@@ -114,7 +114,8 @@ impl<'a, 'b, DB: DrawingBackend + 'a, CT: CoordTranslate> SeriesLabelStyle<'a, '
     /// Draw the series label area
     pub fn draw(&mut self) -> Result<(), DrawingAreaErrorKind<DB::ErrorType>> {
         let drawing_area = self.target.plotting_area().strip_coord_spec();
-        let default_font = ("Arial", 12).into_font();
+
+        let default_font = ("serif", 12).into_font();
         let default_style: TextStyle = default_font.into();
 
         let font = {

--- a/src/drawing/area.rs
+++ b/src/drawing/area.rs
@@ -690,7 +690,7 @@ mod drawing_area_tests {
         let drawing_area = create_mocked_drawing_area(1024, 768, |m| {
             m.check_draw_text(|c, font, size, _pos, text| {
                 assert_eq!(c, BLACK.to_rgba());
-                assert_eq!(font, "Arial");
+                assert_eq!(font, "serif");
                 assert_eq!(size, 30.0);
                 assert_eq!("This is the title", text);
             });
@@ -709,7 +709,7 @@ mod drawing_area_tests {
         });
 
         drawing_area
-            .titled("This is the title", ("Arial", 30))
+            .titled("This is the title", ("serif", 30))
             .unwrap()
             .fill(&WHITE)
             .unwrap();

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -46,7 +46,7 @@
         ) -> Result<(), DrawingErrorKind<DB::ErrorType>> {
             let pos = pos.next().unwrap();
             backend.draw_rect(pos, (pos.0 + 10, pos.1 + 12), &RED.to_rgba(), false)?;
-            backend.draw_text("X", &("Arial", 20).into(), pos, &RED.to_rgba())
+            backend.draw_text("X", &("serif", 20).into(), pos, &RED.to_rgba())
         }
     }
 
@@ -76,9 +76,9 @@
             "plotters-doc-data/element-1.png",
             (640, 480)
         ).into_drawing_area();
-        let font:FontDesc = ("Arial", 20).into();
+        let font:FontDesc = ("serif", 20).into();
         root.draw(&(EmptyElement::at((200, 200))
-                + Text::new("X", (0, 0), &"Arial".into_font().resize(20.0).color(&RED))
+                + Text::new("X", (0, 0), &"serif".into_font().resize(20.0).color(&RED))
                 + Rectangle::new([(0,0), (10, 12)], &RED)
         ))?;
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,7 +265,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let root = BitMapBackend::new("plotters-doc-data/0.png", (640, 480)).into_drawing_area();
     root.fill(&WHITE)?;
     let mut chart = ChartBuilder::on(&root)
-        .caption("y=x^2", ("Arial", 50).into_font())
+        .caption("y=x^2", ("serif", 50).into_font())
         .margin(5)
         .x_label_area_size(30)
         .y_label_area_size(30)
@@ -309,7 +309,7 @@ use plotters::prelude::*;
 let figure = evcxr_figure((640, 480), |root| {
     root.fill(&WHITE);
     let mut chart = ChartBuilder::on(&root)
-        .caption("y=x^2", ("Arial", 50).into_font())
+        .caption("y=x^2", ("serif", 50).into_font())
         .margin(5)
         .x_label_area_size(30)
         .y_label_area_size(30)
@@ -492,7 +492,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             + Text::new(
                 format!("({:.2},{:.2})", x, y),
                 (10, 0),
-                ("Arial", 15.0).into_font(),
+                ("serif", 15.0).into_font(),
             );
     };
 
@@ -521,7 +521,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // After this point, we should be able to draw construct a chart context
     let mut chart = ChartBuilder::on(&root)
         // Set the caption of the chart
-        .caption("This is our first plot", ("Arial", 40).into_font())
+        .caption("This is our first plot", ("serif", 40).into_font())
         // Set the size of the label region
         .x_label_area_size(20)
         .y_label_area_size(40)
@@ -551,7 +551,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &|c, s, st| {
             return EmptyElement::at(c)    // We want to construct a composed element on-the-fly
             + Circle::new((0,0),s,st.filled()) // At this point, the new pixel coordinate is established
-            + Text::new(format!("{:?}", c), (10, 0), ("Arial", 10).into_font());
+            + Text::new(format!("{:?}", c), (10, 0), ("serif", 10).into_font());
         },
     ))?;
     Ok(())
@@ -673,8 +673,9 @@ pub mod prelude {
     pub use crate::drawing::*;
     pub use crate::series::{AreaSeries, Histogram, LineSeries, PointSeries};
     pub use crate::style::{
-        AsRelative, Color, FontDesc, FontTransform, HSLColor, IntoFont, Palette, Palette100,
-        Palette99, Palette9999, PaletteColor, RGBColor, ShapeStyle, SimpleColor, TextStyle,
+        AsRelative, Color, FontDesc, FontFamily, FontTransform, HSLColor, IntoFont, Palette,
+        Palette100, Palette99, Palette9999, PaletteColor, RGBColor, ShapeStyle, SimpleColor,
+        TextStyle,
     };
     pub use crate::style::{BLACK, BLUE, CYAN, GREEN, MAGENTA, RED, TRANSPARENT, WHITE, YELLOW};
 

--- a/src/style/font/mod.rs
+++ b/src/style/font/mod.rs
@@ -25,7 +25,7 @@ pub type LayoutBox = ((i32, i32), (i32, i32));
 
 pub trait FontData: Clone {
     type ErrorType: Sized + std::error::Error + Clone;
-    fn new(face: &str) -> Result<Self, Self::ErrorType>;
+    fn new(family: FontFamily) -> Result<Self, Self::ErrorType>;
     fn estimate_layout(&self, size: f64, text: &str) -> Result<LayoutBox, Self::ErrorType>;
     fn draw<E, DrawFunc: FnMut(i32, i32, f32) -> Result<(), E>>(
         &self,

--- a/src/style/font/ttf.rs
+++ b/src/style/font/ttf.rs
@@ -8,7 +8,7 @@ use rusttype::{point, Error, Font, Scale, SharedBytes};
 use font_loader::system_fonts;
 use font_loader::system_fonts::FontPropertyBuilder;
 
-use super::{FontData, FontTransform, LayoutBox};
+use super::{FontData, FontFamily, FontTransform, LayoutBox};
 
 type FontResult<T> = Result<T, FontError>;
 
@@ -73,9 +73,11 @@ pub struct FontDataInternal(Font<'static>);
 
 impl FontData for FontDataInternal {
     type ErrorType = FontError;
-    fn new(face: &str) -> Result<Self, FontError> {
-        Ok(FontDataInternal(load_font_data(face)?))
+
+    fn new(family: FontFamily) -> Result<Self, FontError> {
+        Ok(FontDataInternal(load_font_data(family.as_str())?))
     }
+
     fn estimate_layout(&self, size: f64, text: &str) -> Result<LayoutBox, Self::ErrorType> {
         let scale = Scale::uniform(size as f32);
 
@@ -99,6 +101,7 @@ impl FontData for FontDataInternal {
 
         Ok(((min_x, min_y), (max_x, max_y)))
     }
+
     fn draw<E, DrawFunc: FnMut(i32, i32, f32) -> Result<(), E>>(
         &self,
         (x, y): (i32, i32),
@@ -143,10 +146,10 @@ mod test {
 
         assert_eq!(CACHE.read().unwrap().len(), 0);
 
-        load_font_data("sans")?;
+        load_font_data("serif")?;
         assert_eq!(CACHE.read().unwrap().len(), 1);
 
-        load_font_data("sans")?;
+        load_font_data("serif")?;
         assert_eq!(CACHE.read().unwrap().len(), 1);
 
         return Ok(());

--- a/src/style/font/web.rs
+++ b/src/style/font/web.rs
@@ -1,4 +1,4 @@
-use super::{FontData, LayoutBox};
+use super::{FontData, FontFamily, LayoutBox};
 use wasm_bindgen::JsCast;
 use web_sys::{window, HtmlElement};
 
@@ -22,8 +22,8 @@ pub struct FontDataInternal(String);
 
 impl FontData for FontDataInternal {
     type ErrorType = FontError;
-    fn new(face: &str) -> Result<Self, FontError> {
-        Ok(FontDataInternal(face.to_string()))
+    fn new(family: FontFamily) -> Result<Self, FontError> {
+        Ok(FontDataInternal(family.as_str().into()))
     }
     fn estimate_layout(&self, size: f64, text: &str) -> Result<LayoutBox, Self::ErrorType> {
         let window = window().unwrap();

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -16,7 +16,7 @@ mod palette_ext;
 pub use self::palette::*;
 pub use color::{Color, HSLColor, PaletteColor, RGBAColor, RGBColor, SimpleColor};
 pub use colors::{BLACK, BLUE, CYAN, GREEN, MAGENTA, RED, TRANSPARENT, WHITE, YELLOW};
-pub use font::{FontDesc, FontError, FontResult, FontTransform, IntoFont, LayoutBox};
+pub use font::{FontDesc, FontError, FontFamily, FontResult, FontTransform, IntoFont, LayoutBox};
 pub use shape::ShapeStyle;
 pub use size::{AsRelative, RelativeSize, SizeDesc};
 pub use text::{IntoTextStyle, TextStyle};

--- a/src/style/text.rs
+++ b/src/style/text.rs
@@ -1,5 +1,5 @@
 use super::color::{Color, RGBAColor};
-use super::font::{FontDesc, FontTransform};
+use super::font::{FontDesc, FontFamily, FontTransform};
 use super::size::{HasDimension, SizeDesc};
 use super::BLACK;
 
@@ -26,7 +26,19 @@ impl<'a> IntoTextStyle<'a> for TextStyle<'a> {
     }
 }
 
+impl<'a> IntoTextStyle<'a> for FontFamily<'a> {
+    fn into_text_style<P: HasDimension>(self, _: &P) -> TextStyle<'a> {
+        self.into()
+    }
+}
+
 impl<'a, T: SizeDesc> IntoTextStyle<'a> for (&'a str, T) {
+    fn into_text_style<P: HasDimension>(self, parent: &P) -> TextStyle<'a> {
+        (self.0, self.1.in_pixels(parent)).into()
+    }
+}
+
+impl<'a, T: SizeDesc> IntoTextStyle<'a> for (FontFamily<'a>, T) {
     fn into_text_style<P: HasDimension>(self, parent: &P) -> TextStyle<'a> {
         (self.0, self.1.in_pixels(parent)).into()
     }


### PR DESCRIPTION
Currently default hardcoded typeface is "Arial", but this font is not
available by default everywhere.

This PR adds new FontFamily enum which can be used as an
alternative to the font name.

Also see #63