### PR TITLE
Embed Device Support: Pixel format + Incremental rendering tweaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Plotters latest (?)
+### Added
+
+- BitMapBackend now is able to support different pixel format natively. Check our new minifb demo for details.
+- Incremental Rendering by saving the previous chart context into a state and restore it on a different drawing area.
 
 ### Improved
 

--- a/examples/minifb-demo/.gitignore
+++ b/examples/minifb-demo/.gitignore
@@ -1,2 +1,0 @@
-/target
-**/*.rs.bk

--- a/examples/minifb-demo/.gitignore
+++ b/examples/minifb-demo/.gitignore
@@ -1,0 +1,2 @@
+/target
+**/*.rs.bk

--- a/examples/minifb-demo/Cargo.toml
+++ b/examples/minifb-demo/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "minifb-demo"
+version = "0.1.0"
+authors = ["Hao Hou <haohou302@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+minifb = "0.13.0"
+plotters = { path = "../.." , default_features = false}

--- a/examples/minifb-demo/src/main.rs
+++ b/examples/minifb-demo/src/main.rs
@@ -1,0 +1,148 @@
+use minifb::{Key, KeyRepeat, Window, WindowOptions};
+use plotters::drawing::bitmap_pixel::BGRXPixel;
+use plotters::prelude::*;
+use std::collections::VecDeque;
+use std::error::Error;
+use std::time::SystemTime;
+const W: usize = 480;
+const H: usize = 320;
+
+const SAMPLE_RATE: f64 = 10_000.0;
+const FREAME_RATE: f64 = 30.0;
+
+fn get_window_title(fx: f64, fy: f64, iphase: f64) -> String {
+    format!(
+        "x={:.1}Hz, y={:.1}Hz, phase={:.1} +/-=Adjust y 9/0=Adjust x <Esc>=Exit",
+        fx, fy, iphase
+    )
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut buf = vec![0u8; W * H * 4];
+
+    let mut fx: f64 = 1.0;
+    let mut fy: f64 = 1.1;
+    let mut xphase: f64 = 0.0;
+    let mut yphase: f64 = 0.1;
+
+    let mut window = Window::new(
+        &get_window_title(fx, fy, yphase - xphase),
+        W,
+        H,
+        WindowOptions::default(),
+    )?;
+    let root =
+        BitMapBackend::<BGRXPixel>::with_buffer_and_format(&mut buf[..], (W as u32, H as u32))?
+            .into_drawing_area();
+    root.fill(&BLACK)?;
+
+    let mut chart = ChartBuilder::on(&root)
+        .margin(10)
+        .set_all_label_area_size(30)
+        .build_ranged(-1.2..1.2, -1.2..1.2)?;
+
+    chart
+        .configure_mesh()
+        .label_style(("sans-serif", 15).into_font().color(&GREEN))
+        .axis_style(&GREEN)
+        .draw()?;
+
+    let cs = chart.into_chart_state();
+    drop(root);
+
+    let mut data = VecDeque::new();
+    let start_ts = SystemTime::now();
+    let mut last_flushed = 0.0;
+
+    while window.is_open() && !window.is_key_down(Key::Escape) {
+        let epoch = SystemTime::now()
+            .duration_since(start_ts)
+            .unwrap()
+            .as_secs_f64();
+
+        if let Some((ts, _, _)) = data.back() {
+            if epoch - ts < 1.0 / SAMPLE_RATE {
+                std::thread::sleep(std::time::Duration::from_secs_f64(epoch - ts));
+                continue;
+            }
+            let mut ts = *ts;
+            while ts < epoch {
+                ts += 1.0 / SAMPLE_RATE;
+                let phase_x: f64 = 2.0 * ts * std::f64::consts::PI * fx + xphase;
+                let phase_y: f64 = 2.0 * ts * std::f64::consts::PI * fy + yphase;
+                data.push_back((ts, phase_x.sin(), phase_y.sin()));
+            }
+        }
+
+        let phase_x = 2.0 * epoch * std::f64::consts::PI * fx + xphase;
+        let phase_y = 2.0 * epoch * std::f64::consts::PI * fy + yphase;
+        data.push_back((epoch, phase_x.sin(), phase_y.sin()));
+
+        if epoch - last_flushed > 1.0 / FREAME_RATE {
+            let root = BitMapBackend::<BGRXPixel>::with_buffer_and_format(
+                &mut buf[..],
+                (W as u32, H as u32),
+            )?
+            .into_drawing_area();
+            let mut chart = cs.clone().restore(&root);
+            chart.plotting_area().fill(&BLACK)?;
+
+            chart
+                .configure_mesh()
+                .line_style_1(&GREEN.mix(0.2))
+                .line_style_2(&TRANSPARENT)
+                .draw()?;
+
+            chart.draw_series(data.iter().zip(data.iter().skip(1)).map(
+                |(&(e, x0, y0), &(_, x1, y1))| {
+                    PathElement::new(
+                        vec![(x0, y0), (x1, y1)],
+                        &GREEN.mix(((e - epoch) * 20.0).exp()),
+                    )
+                },
+            ))?;
+
+            drop(root);
+            drop(chart);
+
+            if let Some(keys) = window.get_keys_pressed(KeyRepeat::Yes) {
+                for key in keys {
+                    let old_fx = fx;
+                    let old_fy = fy;
+                    match key {
+                        Key::Equal => {
+                            fy += 0.1;
+                        }
+                        Key::Minus => {
+                            fy -= 0.1;
+                        }
+                        Key::Key0 => {
+                            fx += 0.1;
+                        }
+                        Key::Key9 => {
+                            fx -= 0.1;
+                        }
+                        _ => {
+                            continue;
+                        }
+                    }
+                    xphase += 2.0 * epoch * std::f64::consts::PI * (old_fx - fx);
+                    yphase += 2.0 * epoch * std::f64::consts::PI * (old_fy - fy);
+
+                    window.set_title(&get_window_title(fx, fy, yphase - xphase));
+                    break;
+                }
+            }
+            window.update_with_buffer(unsafe { std::mem::transmute(&buf[..]) })?;
+            last_flushed = epoch;
+        }
+
+        while let Some((e, _, _)) = data.front() {
+            if ((e - epoch) * 20.0).exp() > 0.1 {
+                break;
+            }
+            data.pop_front();
+        }
+    }
+    Ok(())
+}

--- a/src/chart/builder.rs
+++ b/src/chart/builder.rs
@@ -266,8 +266,8 @@ impl<'a, 'b, DB: DrawingBackend> ChartBuilder<'a, 'b, DB> {
             )),
             series_anno: vec![],
             drawing_area_pos: (
-                actual_drawing_area_pos[2] + title_dx,
-                actual_drawing_area_pos[0] + title_dy,
+                actual_drawing_area_pos[2] + title_dx + self.margin[2] as i32,
+                actual_drawing_area_pos[0] + title_dy + self.margin[0] as i32,
             ),
         })
     }

--- a/src/chart/builder.rs
+++ b/src/chart/builder.rs
@@ -246,7 +246,7 @@ impl<'a, 'b, DB: DrawingBackend> ChartBuilder<'a, 'b, DB> {
         }
 
         let mut pixel_range = drawing_area.get_pixel_range();
-        pixel_range.1 = pixel_range.1.end..pixel_range.1.start;
+        pixel_range.1 = (pixel_range.1.end - 1)..(pixel_range.1.start - 1);
 
         let mut x_label_area = [None, None];
         let mut y_label_area = [None, None];

--- a/src/chart/context.rs
+++ b/src/chart/context.rs
@@ -399,10 +399,7 @@ impl<'a, DB: DrawingBackend, X: Ranged, Y: Ranged> ChartContext<'a, DB, RangedCo
         inward_labels: bool,
     ) -> Result<Range<i32>, DrawingAreaErrorKind<DB::ErrorType>> {
         let (x0, y0) = self.drawing_area.get_base_pixel();
-        let (mut tw, mut th) = area.dim_in_pixel();
-
-        tw -= 1;
-        th -= 1;
+        let (tw, th) = area.dim_in_pixel();
 
         let mut axis_range = if orientation.0 == 0 {
             self.drawing_area.get_x_axis_pixel_range()
@@ -422,26 +419,26 @@ impl<'a, DB: DrawingBackend, X: Ranged, Y: Ranged> ChartContext<'a, DB, RangedCo
         }
 
         if let Some(axis_style) = axis_style {
-            let mut x0 = if orientation.0 > 0 { 1 } else { tw as i32 };
-            let mut y0 = if orientation.1 > 0 { 1 } else { th as i32 };
-            let mut x1 = if orientation.0 >= 0 { 1 } else { tw as i32 };
-            let mut y1 = if orientation.1 >= 0 { 1 } else { th as i32 };
+            let mut x0 = if orientation.0 > 0 { 0 } else { tw as i32 - 1 };
+            let mut y0 = if orientation.1 > 0 { 0 } else { th as i32 - 1 };
+            let mut x1 = if orientation.0 >= 0 { 0 } else { tw as i32 - 1 };
+            let mut y1 = if orientation.1 >= 0 { 0 } else { th as i32 - 1 };
 
             if inward_labels {
                 if orientation.0 == 0 {
-                    if y0 == 1 {
-                        y0 = th as i32;
-                        y1 = th as i32;
+                    if y0 == 0 {
+                        y0 = th as i32 - 1;
+                        y1 = th as i32 - 1;
                     } else {
-                        y0 = 1;
-                        y1 = 1;
+                        y0 = 0;
+                        y1 = 0;
                     }
-                } else if x0 == 1 {
-                    x0 = tw as i32;
-                    x1 = tw as i32;
+                } else if x0 == 0 {
+                    x0 = tw as i32 - 1;
+                    x1 = tw as i32 - 1;
                 } else {
-                    x0 = 1;
-                    x1 = 1;
+                    x0 = 0;
+                    x1 = 0;
                 }
             }
 
@@ -500,10 +497,7 @@ impl<'a, DB: DrawingBackend, X: Ranged, Y: Ranged> ChartContext<'a, DB, RangedCo
         };
 
         let (x0, y0) = self.drawing_area.get_base_pixel();
-        let (mut tw, mut th) = area.dim_in_pixel();
-
-        tw -= 1;
-        th -= 1;
+        let (tw, th) = area.dim_in_pixel();
 
         /* This is the minimal distance from the axis to the box of the labels */
         let label_dist =
@@ -589,28 +583,30 @@ impl<'a, DB: DrawingBackend, X: Ranged, Y: Ranged> ChartContext<'a, DB, RangedCo
                 area.draw_text(&t, label_style, (text_x, text_y))?;
 
                 if let Some(style) = axis_style {
+                    let xmax = tw as i32 - 1;
+                    let ymax = th as i32 - 1;
                     let (kx0, ky0, kx1, ky1) = if tick_size > 0 {
                         match orientation {
-                            (dx, dy) if dx > 0 && dy == 0 => (1, *p - y0, tick_size, *p - y0),
+                            (dx, dy) if dx > 0 && dy == 0 => (0, *p - y0, tick_size, *p - y0),
                             (dx, dy) if dx < 0 && dy == 0 => {
-                                (tw as i32 - tick_size, *p - y0, tw as i32, *p - y0)
+                                (xmax - tick_size, *p - y0, xmax, *p - y0)
                             }
-                            (dx, dy) if dx == 0 && dy > 0 => (*p - x0, 1, *p - x0, tick_size),
+                            (dx, dy) if dx == 0 && dy > 0 => (*p - x0, 0, *p - x0, tick_size),
                             (dx, dy) if dx == 0 && dy < 0 => {
-                                (*p - x0, th as i32 - tick_size, *p - x0, th as i32)
+                                (*p - x0, ymax - tick_size, *p - x0, ymax)
                             }
                             _ => panic!("Bug: Invalid orientation specification"),
                         }
                     } else {
                         match orientation {
                             (dx, dy) if dx > 0 && dy == 0 => {
-                                (tw as i32, *p - y0, tw as i32 + tick_size, *p - y0)
+                                (xmax, *p - y0, xmax + tick_size, *p - y0)
                             }
-                            (dx, dy) if dx < 0 && dy == 0 => (1, *p - y0, -tick_size, *p - y0),
+                            (dx, dy) if dx < 0 && dy == 0 => (0, *p - y0, -tick_size, *p - y0),
                             (dx, dy) if dx == 0 && dy > 0 => {
-                                (*p - x0, th as i32, *p - x0, th as i32 + tick_size)
+                                (*p - x0, ymax, *p - x0, ymax + tick_size)
                             }
-                            (dx, dy) if dx == 0 && dy < 0 => (*p - x0, 1, *p - x0, -tick_size),
+                            (dx, dy) if dx == 0 && dy < 0 => (*p - x0, 0, *p - x0, -tick_size),
                             _ => panic!("Bug: Invalid orientation specification"),
                         }
                     };

--- a/src/chart/context.rs
+++ b/src/chart/context.rs
@@ -399,7 +399,10 @@ impl<'a, DB: DrawingBackend, X: Ranged, Y: Ranged> ChartContext<'a, DB, RangedCo
         inward_labels: bool,
     ) -> Result<Range<i32>, DrawingAreaErrorKind<DB::ErrorType>> {
         let (x0, y0) = self.drawing_area.get_base_pixel();
-        let (tw, th) = area.dim_in_pixel();
+        let (mut tw, mut th) = area.dim_in_pixel();
+
+        tw -= 1;
+        th -= 1;
 
         let mut axis_range = if orientation.0 == 0 {
             self.drawing_area.get_x_axis_pixel_range()
@@ -419,26 +422,26 @@ impl<'a, DB: DrawingBackend, X: Ranged, Y: Ranged> ChartContext<'a, DB, RangedCo
         }
 
         if let Some(axis_style) = axis_style {
-            let mut x0 = if orientation.0 > 0 { 0 } else { tw as i32 };
-            let mut y0 = if orientation.1 > 0 { 0 } else { th as i32 };
-            let mut x1 = if orientation.0 >= 0 { 0 } else { tw as i32 };
-            let mut y1 = if orientation.1 >= 0 { 0 } else { th as i32 };
+            let mut x0 = if orientation.0 > 0 { 1 } else { tw as i32 };
+            let mut y0 = if orientation.1 > 0 { 1 } else { th as i32 };
+            let mut x1 = if orientation.0 >= 0 { 1 } else { tw as i32 };
+            let mut y1 = if orientation.1 >= 0 { 1 } else { th as i32 };
 
             if inward_labels {
                 if orientation.0 == 0 {
-                    if y0 == 0 {
+                    if y0 == 1 {
                         y0 = th as i32;
                         y1 = th as i32;
                     } else {
-                        y0 = 0;
-                        y1 = 0;
+                        y0 = 1;
+                        y1 = 1;
                     }
-                } else if x0 == 0 {
+                } else if x0 == 1 {
                     x0 = tw as i32;
                     x1 = tw as i32;
                 } else {
-                    x0 = 0;
-                    x1 = 0;
+                    x0 = 1;
+                    x1 = 1;
                 }
             }
 
@@ -497,7 +500,10 @@ impl<'a, DB: DrawingBackend, X: Ranged, Y: Ranged> ChartContext<'a, DB, RangedCo
         };
 
         let (x0, y0) = self.drawing_area.get_base_pixel();
-        let (tw, th) = area.dim_in_pixel();
+        let (mut tw, mut th) = area.dim_in_pixel();
+
+        tw -= 1;
+        th -= 1;
 
         /* This is the minimal distance from the axis to the box of the labels */
         let label_dist =
@@ -585,11 +591,11 @@ impl<'a, DB: DrawingBackend, X: Ranged, Y: Ranged> ChartContext<'a, DB, RangedCo
                 if let Some(style) = axis_style {
                     let (kx0, ky0, kx1, ky1) = if tick_size > 0 {
                         match orientation {
-                            (dx, dy) if dx > 0 && dy == 0 => (0, *p - y0, tick_size, *p - y0),
+                            (dx, dy) if dx > 0 && dy == 0 => (1, *p - y0, tick_size, *p - y0),
                             (dx, dy) if dx < 0 && dy == 0 => {
                                 (tw as i32 - tick_size, *p - y0, tw as i32, *p - y0)
                             }
-                            (dx, dy) if dx == 0 && dy > 0 => (*p - x0, 0, *p - x0, tick_size),
+                            (dx, dy) if dx == 0 && dy > 0 => (*p - x0, 1, *p - x0, tick_size),
                             (dx, dy) if dx == 0 && dy < 0 => {
                                 (*p - x0, th as i32 - tick_size, *p - x0, th as i32)
                             }
@@ -600,11 +606,11 @@ impl<'a, DB: DrawingBackend, X: Ranged, Y: Ranged> ChartContext<'a, DB, RangedCo
                             (dx, dy) if dx > 0 && dy == 0 => {
                                 (tw as i32, *p - y0, tw as i32 + tick_size, *p - y0)
                             }
-                            (dx, dy) if dx < 0 && dy == 0 => (0, *p - y0, -tick_size, *p - y0),
+                            (dx, dy) if dx < 0 && dy == 0 => (1, *p - y0, -tick_size, *p - y0),
                             (dx, dy) if dx == 0 && dy > 0 => {
                                 (*p - x0, th as i32, *p - x0, th as i32 + tick_size)
                             }
-                            (dx, dy) if dx == 0 && dy < 0 => (*p - x0, 0, *p - x0, -tick_size),
+                            (dx, dy) if dx == 0 && dy < 0 => (*p - x0, 1, *p - x0, -tick_size),
                             _ => panic!("Bug: Invalid orientation specification"),
                         }
                     };

--- a/src/chart/dual_coord.rs
+++ b/src/chart/dual_coord.rs
@@ -19,6 +19,8 @@ pub struct DualCoordChartContext<'a, DB: DrawingBackend, CT1: CoordTranslate, CT
     pub(super) secondary: ChartContext<'a, DB, CT2>,
 }
 
+/// The chart state for a dual coord chart, see the detailed description for `ChartState` for more
+/// information about the purpose of a chart state
 pub struct DualCoordChartState<CT1: CoordTranslate, CT2: CoordTranslate> {
     primary: ChartState<CT1>,
     secondary: ChartState<CT2>,
@@ -27,6 +29,7 @@ pub struct DualCoordChartState<CT1: CoordTranslate, CT2: CoordTranslate> {
 impl<'a, DB: DrawingBackend, CT1: CoordTranslate, CT2: CoordTranslate>
     DualCoordChartContext<'a, DB, CT1, CT2>
 {
+    /// Convert the chart context into a chart state
     pub fn into_chart_state(self) -> DualCoordChartState<CT1, CT2> {
         DualCoordChartState {
             primary: self.primary.into(),
@@ -34,6 +37,7 @@ impl<'a, DB: DrawingBackend, CT1: CoordTranslate, CT2: CoordTranslate>
         }
     }
 
+    /// Convert the chart context into a sharable chart state
     pub fn into_shared_chart_state(self) -> DualCoordChartState<Arc<CT1>, Arc<CT2>> {
         DualCoordChartState {
             primary: self.primary.into_shared_chart_state(),
@@ -48,6 +52,7 @@ where
     CT1: Clone,
     CT2: Clone,
 {
+    /// Copy the coordinate specs and make the chart state
     pub fn to_chart_state(&self) -> DualCoordChartState<CT1, CT2> {
         DualCoordChartState {
             primary: self.primary.to_chart_state(),
@@ -57,6 +62,7 @@ where
 }
 
 impl<CT1: CoordTranslate, CT2: CoordTranslate> DualCoordChartState<CT1, CT2> {
+    /// Restore the chart state on the given drawing area
     pub fn restore<'a, DB: DrawingBackend + 'a>(
         self,
         area: &DrawingArea<DB, Shift>,

--- a/src/coord/ranged.rs
+++ b/src/coord/ranged.rs
@@ -21,7 +21,11 @@ pub trait Ranged {
 
     /// This function provides the on-axis part of its range
     fn axis_pixel_range(&self, limit: (i32, i32)) -> Range<i32> {
-        limit.0..limit.1
+        if limit.0 < limit.1 {
+            limit.0..limit.1
+        } else {
+            (limit.1 + 1)..(limit.0 + 1)
+        }
     }
 }
 

--- a/src/drawing/area.rs
+++ b/src/drawing/area.rs
@@ -278,7 +278,7 @@ impl<DB: DrawingBackend, CT: CoordTranslate> DrawingArea<DB, CT> {
         self.backend_ops(|backend| {
             backend.draw_rect(
                 (self.rect.x0, self.rect.y0),
-                (self.rect.x1, self.rect.y1),
+                (self.rect.x1 - 1, self.rect.y1 - 1),
                 color,
                 true,
             )
@@ -541,7 +541,7 @@ mod drawing_area_tests {
                 assert_eq!(c, WHITE.to_rgba());
                 assert_eq!(f, true);
                 assert_eq!(u, (0, 0));
-                assert_eq!(d, (1024, 768));
+                assert_eq!(d, (1023, 767));
             });
 
             m.drop_check(|b| {
@@ -569,8 +569,8 @@ mod drawing_area_tests {
                         assert_eq!(
                             d,
                             (
-                                300 + 300 * row as i32 + 2.min(row + 1) as i32,
-                                300 + 300 * col as i32
+                                300 + 300 * row as i32 + 2.min(row + 1) as i32 - 1,
+                                300 + 300 * col as i32 - 1
                             )
                         );
                     });
@@ -598,14 +598,14 @@ mod drawing_area_tests {
                 assert_eq!(c, RED.to_rgba());
                 assert_eq!(f, true);
                 assert_eq!(u, (0, 0));
-                assert_eq!(d, (345, 768));
+                assert_eq!(d, (345 - 1, 768 - 1));
             });
 
             m.check_draw_rect(|c, _, f, u, d| {
                 assert_eq!(c, BLUE.to_rgba());
                 assert_eq!(f, true);
                 assert_eq!(u, (345, 0));
-                assert_eq!(d, (1024, 768));
+                assert_eq!(d, (1024 - 1, 768 - 1));
             });
 
             m.drop_check(|b| {
@@ -626,14 +626,14 @@ mod drawing_area_tests {
                 assert_eq!(c, RED.to_rgba());
                 assert_eq!(f, true);
                 assert_eq!(u, (0, 0));
-                assert_eq!(d, (1024, 345));
+                assert_eq!(d, (1024 - 1, 345 - 1));
             });
 
             m.check_draw_rect(|c, _, f, u, d| {
                 assert_eq!(c, BLUE.to_rgba());
                 assert_eq!(f, true);
                 assert_eq!(u, (0, 345));
-                assert_eq!(d, (1024, 768));
+                assert_eq!(d, (1024 - 1, 768 - 1));
             });
 
             m.drop_check(|b| {
@@ -670,8 +670,10 @@ mod drawing_area_tests {
                             };
 
                             let expected_u = (get_bp(1024, nxb, col), get_bp(768, nyb, row));
-                            let expected_d =
-                                (get_bp(1024, nxb, col + 1), get_bp(768, nyb, row + 1));
+                            let expected_d = (
+                                get_bp(1024, nxb, col + 1) - 1,
+                                get_bp(768, nyb, row + 1) - 1,
+                            );
                             let expected_color =
                                 colors[(row * (nxb + 1) + col) as usize % colors.len()];
 
@@ -714,7 +716,7 @@ mod drawing_area_tests {
                 assert_eq!(f, true);
                 assert_eq!(u.0, 0);
                 assert!(u.1 > 0);
-                assert_eq!(d, (1024, 768));
+                assert_eq!(d, (1024 - 1, 768 - 1));
             });
             m.drop_check(|b| {
                 assert_eq!(b.num_draw_text_call, 1);
@@ -737,7 +739,7 @@ mod drawing_area_tests {
                 assert_eq!(c, WHITE.to_rgba());
                 assert_eq!(f, true);
                 assert_eq!(u, (3, 1));
-                assert_eq!(d, (1024 - 4, 768 - 2));
+                assert_eq!(d, (1024 - 4 - 1, 768 - 2 - 1));
             });
 
             m.drop_check(|b| {
@@ -796,22 +798,22 @@ mod drawing_area_tests {
                     0 => {
                         assert_eq!(c, RED.to_rgba());
                         assert_eq!(u, (0, 0));
-                        assert_eq!(d, (300, 600));
+                        assert_eq!(d, (300 - 1, 600 - 1));
                     }
                     1 => {
                         assert_eq!(c, BLUE.to_rgba());
                         assert_eq!(u, (300, 0));
-                        assert_eq!(d, (1000, 600));
+                        assert_eq!(d, (1000 - 1, 600 - 1));
                     }
                     2 => {
                         assert_eq!(c, GREEN.to_rgba());
                         assert_eq!(u, (0, 600));
-                        assert_eq!(d, (300, 1200));
+                        assert_eq!(d, (300 - 1, 1200 - 1));
                     }
                     3 => {
                         assert_eq!(c, WHITE.to_rgba());
                         assert_eq!(u, (300, 600));
-                        assert_eq!(d, (1000, 1200));
+                        assert_eq!(d, (1000 - 1, 1200 - 1));
                     }
                     _ => panic!("Too many draw rect"),
                 }
@@ -839,7 +841,7 @@ mod drawing_area_tests {
         let drawing_area = create_mocked_drawing_area(1000, 1200, |m| {
             m.check_draw_rect(move |_, _, _, u, d| {
                 assert_eq!((100, 100), u);
-                assert_eq!((300, 700), d);
+                assert_eq!((300 - 1, 700 - 1), d);
             });
 
             m.drop_check(|b| {

--- a/src/drawing/backend.rs
+++ b/src/drawing/backend.rs
@@ -219,6 +219,10 @@ pub trait DrawingBackend: Sized {
     ///
     /// - `text`: pos the left upper conner of the bitmap to blit
     /// - `src`: The source of the image
+    ///
+    /// TODO: The default implementation of bitmap blitting assumes that the bitmap is RGB, but
+    /// this may not be the case. But for bitmap backend it's actually ok if we use the bitmap
+    /// element that matches the pixel format, but we need to fix this.
     fn blit_bitmap<'a>(
         &mut self,
         pos: BackendCoord,

--- a/src/drawing/backend_impl/bitmap.rs
+++ b/src/drawing/backend_impl/bitmap.rs
@@ -1212,7 +1212,7 @@ fn test_bitmap_bgrx_pixel_format() {
         let mut rgb_back = BitMapBackend::with_buffer(&mut rgb_buffer, (1000, 1000));
         let mut bgrx_back =
             BitMapBackend::<BGRXPixel>::with_buffer_and_format(&mut bgrx_buffer, (1000, 1000))
-            .unwrap();
+                .unwrap();
 
         rgb_back
             .draw_rect((0, 0), (1000, 1000), &BLACK, true)

--- a/src/drawing/backend_impl/bitmap.rs
+++ b/src/drawing/backend_impl/bitmap.rs
@@ -132,6 +132,9 @@ pub trait PixelFormat: Sized {
     /// Encoding a pixel and returns the idx-th byte for the pixel
     fn byte_at(r: u8, g: u8, b: u8, a: u64, idx: usize) -> u8;
 
+    /// Decode a pixel at the given location
+    fn decode_pixel(data: &[u8]) -> (u8, u8, u8, u64);
+
     /// The fast alpha blending algorithm for this pixel format
     ///
     /// - `target`: The target bitmap backend
@@ -269,6 +272,11 @@ impl PixelFormat for RGBPixel {
             2 => b,
             _ => 0xff,
         }
+    }
+
+    #[inline(always)]
+    fn decode_pixel(data: &[u8]) -> (u8, u8, u8, u64) {
+        (data[0], data[1], data[2], 0x255)
     }
 
     fn can_be_saved() -> bool {
@@ -483,6 +491,11 @@ impl PixelFormat for BGRXPixel {
             2 => r,
             _ => 0xff,
         }
+    }
+
+    #[inline(always)]
+    fn decode_pixel(data: &[u8]) -> (u8, u8, u8, u64) {
+        (data[2], data[1], data[0], 0x255)
     }
 
     fn blend_rect_fast(

--- a/src/drawing/backend_impl/mod.rs
+++ b/src/drawing/backend_impl/mod.rs
@@ -7,7 +7,7 @@ mod bitmap;
 pub use bitmap::BitMapBackend;
 
 pub mod bitmap_pixel {
-    pub use super::bitmap::{BGRXPixel, RGBPixel};
+    pub use super::bitmap::{BGRXPixel, PixelFormat, RGBPixel};
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/src/drawing/backend_impl/mod.rs
+++ b/src/drawing/backend_impl/mod.rs
@@ -6,6 +6,10 @@ pub use self::svg::{svg_types, SVGBackend};
 mod bitmap;
 pub use bitmap::BitMapBackend;
 
+pub mod bitmap_pixel {
+    pub use super::bitmap::{BGRXPixel, RGBPixel};
+}
+
 #[cfg(target_arch = "wasm32")]
 mod canvas;
 #[cfg(target_arch = "wasm32")]

--- a/src/element/image.rs
+++ b/src/element/image.rs
@@ -3,18 +3,21 @@ use image::{DynamicImage, GenericImageView};
 
 use super::{Drawable, PointCollection};
 use crate::drawing::backend::{BackendCoord, DrawingBackend, DrawingErrorKind};
+use crate::drawing::bitmap_pixel::{PixelFormat, RGBPixel};
 
 use crate::drawing::BitMapBackend;
 use std::borrow::{Borrow, Cow};
+use std::marker::PhantomData;
 
 /// The element that contains a bitmap on it
-pub struct BitMapElement<'a, Coord> {
+pub struct BitMapElement<'a, Coord, P: PixelFormat = RGBPixel> {
     image: Cow<'a, Vec<u8>>,
     size: (u32, u32),
     pos: Coord,
+    phantom: PhantomData<P>,
 }
 
-impl<'a, Coord> BitMapElement<'a, Coord> {
+impl<'a, Coord, P: PixelFormat> BitMapElement<'a, Coord, P> {
     /// Create a new empty bitmap element. This can be use as
     /// the draw and blit pattern.
     ///
@@ -22,20 +25,22 @@ impl<'a, Coord> BitMapElement<'a, Coord> {
     /// - `size`: The size of the bitmap
     pub fn new(pos: Coord, size: (u32, u32)) -> Self {
         Self {
-            image: Cow::Owned(vec![0; (size.0 * size.1 * 3) as usize]),
+            image: Cow::Owned(vec![0; (size.0 * size.1) as usize * P::PIXEL_SIZE]),
             size,
             pos,
+            phantom: PhantomData,
         }
     }
 
     /// Copy the existing bitmap element to another location
     ///
     /// - `pos`: The new location to copy
-    pub fn copy_to<Coord2>(&self, pos: Coord2) -> BitMapElement<Coord2> {
+    pub fn copy_to<Coord2>(&self, pos: Coord2) -> BitMapElement<Coord2, P> {
         BitMapElement {
             image: Cow::Borrowed(self.image.borrow()),
             size: self.size,
             pos,
+            phantom: PhantomData,
         }
     }
 
@@ -48,13 +53,13 @@ impl<'a, Coord> BitMapElement<'a, Coord> {
 
     /// Make the bitmap element as a bitmap backend, so that we can use
     /// plotters drawing functionality on the bitmap element
-    pub fn as_bitmap_backend(&mut self) -> BitMapBackend {
-        BitMapBackend::with_buffer(self.image.to_mut(), self.size)
+    pub fn as_bitmap_backend(&mut self) -> BitMapBackend<P> {
+        BitMapBackend::with_buffer_and_format(self.image.to_mut(), self.size).unwrap()
     }
 }
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "image"))]
-impl<'a, Coord> From<(Coord, DynamicImage)> for BitMapElement<'a, Coord> {
+impl<'a, Coord> From<(Coord, DynamicImage)> for BitMapElement<'a, Coord, RGBPixel> {
     fn from((pos, image): (Coord, DynamicImage)) -> Self {
         let (w, h) = image.dimensions();
         let rgb_image = image.to_rgb().into_raw();
@@ -62,6 +67,23 @@ impl<'a, Coord> From<(Coord, DynamicImage)> for BitMapElement<'a, Coord> {
             pos,
             image: Cow::Owned(rgb_image),
             size: (w, h),
+            phantom: PhantomData,
+        }
+    }
+}
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "image"))]
+impl<'a, Coord> From<(Coord, DynamicImage)>
+    for BitMapElement<'a, Coord, crate::drawing::bitmap_pixel::BGRXPixel>
+{
+    fn from((pos, image): (Coord, DynamicImage)) -> Self {
+        let (w, h) = image.dimensions();
+        let rgb_image = image.to_bgra().into_raw();
+        Self {
+            pos,
+            image: Cow::Owned(rgb_image),
+            size: (w, h),
+            phantom: PhantomData,
         }
     }
 }
@@ -82,6 +104,7 @@ impl<'a, Coord, DB: DrawingBackend> Drawable<DB> for BitMapElement<'a, Coord> {
         _: (u32, u32),
     ) -> Result<(), DrawingErrorKind<DB::ErrorType>> {
         if let Some((x, y)) = points.next() {
+            // TODO: convert the pixel format when needed
             return backend.blit_bitmap((x, y), self.size, self.image.as_ref());
         }
         Ok(())

--- a/src/series/line_series.rs
+++ b/src/series/line_series.rs
@@ -44,7 +44,7 @@ mod test {
                 assert_eq!(c, RED.to_rgba());
                 assert_eq!(s, 3);
                 for i in 0..100 {
-                    assert_eq!(path[i], (i as i32 * 2, 200 - i as i32 * 2));
+                    assert_eq!(path[i], (i as i32 * 2, 200 - i as i32 * 2 - 1));
                 }
             });
 

--- a/src/style/color.rs
+++ b/src/style/color.rs
@@ -48,10 +48,12 @@ pub trait Color {
 pub struct RGBAColor(pub(super) u8, pub(super) u8, pub(super) u8, pub(super) f64);
 
 impl Color for RGBAColor {
+    #[inline(always)]
     fn rgb(&self) -> (u8, u8, u8) {
         (self.0, self.1, self.2)
     }
 
+    #[inline(always)]
     fn alpha(&self) -> f64 {
         self.3
     }


### PR DESCRIPTION
This PR closes #70 

# Background
This change particularly about making Plotters works on embed devices. 

Currently we have RGB pixel format by default. However, some issue mentioned using Plotters to manipulate framebuffer while the most common pixel format for a framebuffer is BGRX. This requires pixel format conversion which waste most of the CPU time. 

I am currently digging into how Plotters works with some embed devices and using framebuffer for realtime data visualization. In this case, it's critical to support the native pixel format for those devices. 

# After the change

- BGRX pixel format would be natively supported, which greatly improves  framebuffer target. (Both real framebuffer and minifb)
- Adding more pixel format would be easy than before
- Introduced new fast alpha blending algorithm, which gives 5x speed up for rectangle blending.
- Tweak the chart layout and make sure incremental rendering works properly.

# Todo list

- [x] Documenting the newly added stuff
- [x] Adding benchmark for BGRX pixel format
- [x] Verify there's no breaking change 