### PR TITLE
PistonBackend::new() as public to enable custom piston integration

### DIFF
--- a/src/drawing/backend_impl/piston.rs
+++ b/src/drawing/backend_impl/piston.rs
@@ -35,7 +35,7 @@ fn make_point_pair(a: BackendCoord, b: BackendCoord, scale: f64) -> [f64; 4] {
 }
 
 impl<'a, 'b> PistonBackend<'a, 'b> {
-    fn new(size: (u32, u32), scale: f64, context: Context, graphics: &'b mut G2d<'a>) -> Self {
+    pub fn new(size: (u32, u32), scale: f64, context: Context, graphics: &'b mut G2d<'a>) -> Self {
         Self {
             size,
             context,


### PR DESCRIPTION
Other backends have also ::new-functions made as public. I wanted to use plotters for rendering but also Piston events, impossible if not able to create backend manually.