### PR TITLE
Text anchor positions have been added.

### DIFF
--- a/examples/boxplot.rs
+++ b/examples/boxplot.rs
@@ -80,7 +80,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .configure_mesh()
         .x_desc("Ping, ms")
         .y_desc(category.name())
-        .y_labels(category.len())
         .line_style_2(&WHITE)
         .draw()?;
 
@@ -94,13 +93,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .offset(*offset)
             }))?
             .label(label)
-            .legend(move |(x, y)| Rectangle::new([(x - 5, y - 5), (x + 5, y + 5)], style.filled()));
+            .legend(move |(x, y)| Rectangle::new([(x, y - 3), (x + 12, y + 9)], style.filled()));
     }
     chart
         .configure_series_labels()
         .position(SeriesLabelPosition::UpperRight)
         .background_style(WHITE.filled())
         .border_style(&BLACK.mix(0.5))
+        .legend_area_size(22)
         .draw()?;
 
     let drawing_areas = lower.split_evenly((1, 2));

--- a/examples/boxplot.rs
+++ b/examples/boxplot.rs
@@ -80,6 +80,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .configure_mesh()
         .x_desc("Ping, ms")
         .y_desc(category.name())
+        .y_labels(category.len())
         .line_style_2(&WHITE)
         .draw()?;
 

--- a/examples/minifb-demo/Cargo.toml
+++ b/examples/minifb-demo/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 
 [dependencies]
 minifb = "0.13.0"
-plotters = { path = "../.." , default_features = false}
+plotters = { path = "../.." , default_features = false, features = ["bitmap"]}

--- a/src/chart/context.rs
+++ b/src/chart/context.rs
@@ -570,16 +570,24 @@ impl<'a, DB: DrawingBackend, X: Ranged, Y: Ranged> ChartContext<'a, DB, RangedCo
                     let (kx0, ky0, kx1, ky1) = if tick_size > 0 {
                         match orientation {
                             (dx, dy) if dx > 0 && dy == 0 => (0, *p - y0, tick_size, *p - y0),
-                            (dx, dy) if dx < 0 && dy == 0 => (xmax - tick_size, *p - y0, xmax, *p - y0),
+                            (dx, dy) if dx < 0 && dy == 0 => {
+                                (xmax - tick_size, *p - y0, xmax, *p - y0)
+                            }
                             (dx, dy) if dx == 0 && dy > 0 => (*p - x0, 0, *p - x0, tick_size),
-                            (dx, dy) if dx == 0 && dy < 0 => (*p - x0, ymax - tick_size, *p - x0, ymax),
+                            (dx, dy) if dx == 0 && dy < 0 => {
+                                (*p - x0, ymax - tick_size, *p - x0, ymax)
+                            }
                             _ => panic!("Bug: Invalid orientation specification"),
                         }
                     } else {
                         match orientation {
-                            (dx, dy) if dx > 0 && dy == 0 => (xmax, *p - y0, xmax + tick_size, *p - y0),
+                            (dx, dy) if dx > 0 && dy == 0 => {
+                                (xmax, *p - y0, xmax + tick_size, *p - y0)
+                            }
                             (dx, dy) if dx < 0 && dy == 0 => (0, *p - y0, -tick_size, *p - y0),
-                            (dx, dy) if dx == 0 && dy > 0 => (*p - x0, ymax, *p - x0, ymax + tick_size),
+                            (dx, dy) if dx == 0 && dy > 0 => {
+                                (*p - x0, ymax, *p - x0, ymax + tick_size)
+                            }
                             (dx, dy) if dx == 0 && dy < 0 => (*p - x0, 0, *p - x0, -tick_size),
                             _ => panic!("Bug: Invalid orientation specification"),
                         }

--- a/src/chart/series.rs
+++ b/src/chart/series.rs
@@ -25,21 +25,21 @@ impl SeriesLabelPosition {
         use SeriesLabelPosition::*;
         (
             match self {
-                UpperLeft | MiddleLeft | LowerLeft => 0,
+                UpperLeft | MiddleLeft | LowerLeft => 5,
                 UpperMiddle | MiddleMiddle | LowerMiddle => {
                     (area_dim.0 as i32 - label_dim.0 as i32) / 2
                 }
-                UpperRight | MiddleRight | LowerRight => area_dim.0 as i32 - label_dim.0 as i32,
+                UpperRight | MiddleRight | LowerRight => area_dim.0 as i32 - label_dim.0 as i32 - 5,
                 Coordinate(x, _) => *x,
-            } - 5,
+            },
             match self {
-                UpperLeft | UpperMiddle | UpperRight => 0,
+                UpperLeft | UpperMiddle | UpperRight => 5,
                 MiddleLeft | MiddleMiddle | MiddleRight => {
                     (area_dim.1 as i32 - label_dim.1 as i32) / 2
                 }
-                LowerLeft | LowerMiddle | LowerRight => area_dim.1 as i32 - label_dim.1 as i32,
+                LowerLeft | LowerMiddle | LowerRight => area_dim.1 as i32 - label_dim.1 as i32 - 5,
                 Coordinate(_, y) => *y,
-            } - 5,
+            },
         )
     }
 }

--- a/src/coord/category.rs
+++ b/src/coord/category.rs
@@ -141,7 +141,6 @@ impl<T: PartialEq> Ranged for Category<T> {
     type ValueType = Category<T>;
 
     fn range(&self) -> Range<Category<T>> {
-        //self.0.clone()..self.1.clone()
         let mut left = self.clone();
         let mut right = self.clone();
         left.idx = 0;
@@ -151,14 +150,14 @@ impl<T: PartialEq> Ranged for Category<T> {
 
     fn map(&self, value: &Self::ValueType, limit: (i32, i32)) -> i32 {
         // Add margins to spans as edge values are not applicable to category
-        let total_span = (self.len() + 2) as f64;
+        let total_span = (self.len() + 1) as f64;
         let value_span = f64::from(value.idx + 1);
         (f64::from(limit.1 - limit.0) * value_span / total_span) as i32 + limit.0
     }
 
     fn key_points(&self, max_points: usize) -> Vec<Self::ValueType> {
         let mut ret = vec![];
-        let intervals = self.len() as f64;
+        let intervals = (self.len() - 1) as f64;
         let elements = &self.elements;
         let name = &self.name;
         let step = (intervals / max_points as f64 + 1.0) as usize;
@@ -201,7 +200,10 @@ mod test {
     #[test]
     fn test_ranged_trait() {
         let category = Category::new("color", vec!["red", "green", "blue"]);
-        assert_eq!(category.map(&category.get(&"red").unwrap(), (10, 20)), 12);
+        assert_eq!(category.map(&category.get(&"red").unwrap(), (0, 8)), 2);
+        assert_eq!(category.map(&category.get(&"green").unwrap(), (0, 8)), 4);
+        assert_eq!(category.map(&category.get(&"blue").unwrap(), (0, 8)), 6);
+        assert_eq!(category.key_points(3).len(), 3);
         assert_eq!(category.key_points(5).len(), 3);
     }
 }

--- a/src/drawing/area.rs
+++ b/src/drawing/area.rs
@@ -2,7 +2,8 @@
 use super::backend::{BackendCoord, DrawingBackend, DrawingErrorKind};
 use crate::coord::{CoordTranslate, MeshLine, Ranged, RangedCoord, Shift};
 use crate::element::{Drawable, PointCollection};
-use crate::style::{Color, FontDesc, SizeDesc, TextAlignment, TextStyle};
+use crate::style::text_anchor::{HPos, Pos, VPos};
+use crate::style::{Color, FontDesc, SizeDesc, TextStyle};
 
 use std::borrow::Borrow;
 use std::cell::RefCell;
@@ -472,16 +473,12 @@ impl<DB: DrawingBackend> DrawingArea<DB, Shift> {
     ) -> Result<Self, DrawingAreaError<DB>> {
         let style = style.into();
 
-        let (text_w, text_h) = self.estimate_text_size(text, &style.font)?;
+        let x_padding = (self.rect.x1 - self.rect.x0) / 2;
 
-        let x_padding = if self.rect.x1 - self.rect.x0 > text_w as i32 {
-            (self.rect.x1 - self.rect.x0 - text_w as i32) / 2
-        } else {
-            0
-        };
-
+        let (_, text_h) = self.estimate_text_size(text, &style.font)?;
         let y_padding = (text_h / 2).min(5) as i32;
-        let style = &style.alignment(TextAlignment::Center);
+
+        let style = &style.pos(Pos::new(HPos::Center, VPos::Top));
 
         self.backend_ops(|b| {
             b.draw_text(

--- a/src/drawing/backend.rs
+++ b/src/drawing/backend.rs
@@ -202,14 +202,14 @@ pub trait DrawingBackend: Sized {
             HPos::Center => -width / 2,
         };
         let dy = match style.pos.v_pos {
-            VPos::Top => height,
-            VPos::Center => height / 2,
-            VPos::Bottom => 0,
+            VPos::Top => 0,
+            VPos::Center => -height / 2,
+            VPos::Bottom => -height,
         };
         let trans = font.get_transform();
         let (w, h) = self.get_size();
         match font.draw(text, (0, 0), |x, y, v| {
-            let (x, y) = trans.transform(x + dx - min_x, y + dy - max_y);
+            let (x, y) = trans.transform(x + dx - min_x, y + dy - min_y);
             let (x, y) = (pos.0 + x, pos.1 + y);
             if x >= 0 && x < w as i32 && y >= 0 && y < h as i32 {
                 self.draw_pixel((x, y), &color.mix(f64::from(v)))

--- a/src/drawing/backend_impl/bitmap.rs
+++ b/src/drawing/backend_impl/bitmap.rs
@@ -231,7 +231,7 @@ pub trait PixelFormat: Sized {
                         *buf.get_unchecked_mut(base + idx) = Self::byte_at(r, g, b, 0, idx);
                     }
                 } else {
-                    let alpha = alpha.min(1.0).max(0.0);
+                    let alpha = alpha.min(255.0 / 256.0).max(0.0);
                     if alpha == 0.0 {
                         return;
                     }
@@ -1417,11 +1417,14 @@ mod test {
 
     #[test]
     fn test_text_draw() {
-        let (width, height) = (1000, 500);
+        let (width, height) = (1000, 600);
         let mut buffer = vec![0; (width * height * 3) as usize];
         {
             let root = BitMapBackend::with_buffer(&mut buffer, (width, height)).into_drawing_area();
             root.fill(&WHITE).unwrap();
+            let root = root
+                .titled("Image Title", ("sans-serif", 60).into_font())
+                .unwrap();
 
             let mut chart = ChartBuilder::on(&root)
                 .caption("All anchor point positions", ("sans-serif", 20))

--- a/src/drawing/backend_impl/bitmap.rs
+++ b/src/drawing/backend_impl/bitmap.rs
@@ -1417,7 +1417,7 @@ mod test {
 
     #[test]
     fn test_text_draw() {
-        let (width, height) = (1000, 600);
+        let (width, height) = (1500, 800);
         let mut buffer = vec![0; (width * height * 3) as usize];
         {
             let root = BitMapBackend::with_buffer(&mut buffer, (width, height)).into_drawing_area();
@@ -1441,6 +1441,8 @@ mod test {
                 .draw()
                 .unwrap();
 
+            let ((x1, y1), (x2, y2), (x3, y3)) = ((-30, 30), (0, -30), (30, 30));
+
             for (dy, trans) in [
                 FontTransform::None,
                 FontTransform::Rotate90,
@@ -1452,13 +1454,18 @@ mod test {
             {
                 for (dx1, h_pos) in [HPos::Left, HPos::Right, HPos::Center].iter().enumerate() {
                     for (dx2, v_pos) in [VPos::Top, VPos::Center, VPos::Bottom].iter().enumerate() {
-                        let x = 100_i32 + (dx1 as i32 * 3 + dx2 as i32) * 100;
-                        let y = 100 + dy as i32 * 100;
-                        root.draw(&Circle::new((x, y), 3, &BLACK.mix(0.5))).unwrap();
-                        let style = TextStyle::from(("sans-serif", 20).into_font())
-                            .pos(Pos::new(*h_pos, *v_pos))
-                            .transform(trans.clone());
-                        root.draw_text("test", &style, (x, y)).unwrap();
+                        let x = 150_i32 + (dx1 as i32 * 3 + dx2 as i32) * 150;
+                        let y = 120 + dy as i32 * 150;
+                        let draw = |x, y, text| {
+                            root.draw(&Circle::new((x, y), 3, &BLACK.mix(0.5))).unwrap();
+                            let style = TextStyle::from(("sans-serif", 20).into_font())
+                                .pos(Pos::new(*h_pos, *v_pos))
+                                .transform(trans.clone());
+                            root.draw_text(text, &style, (x, y)).unwrap();
+                        };
+                        draw(x + x1, y + y1, "dood");
+                        draw(x + x2, y + y2, "dog");
+                        draw(x + x3, y + y3, "goog");
                     }
                 }
             }
@@ -1564,9 +1571,15 @@ mod test {
             root.fill(&WHITE).unwrap();
             for i in -20..20 {
                 let alpha = i as f64 * 0.1;
-                root.draw_pixel((50 + i, 50 + i), &BLACK.mix(alpha)).unwrap();
+                root.draw_pixel((50 + i, 50 + i), &BLACK.mix(alpha))
+                    .unwrap();
             }
         }
-        checked_save_file("test_draw_pixel_alphas", &buffer, width as u32, height as u32);
+        checked_save_file(
+            "test_draw_pixel_alphas",
+            &buffer,
+            width as u32,
+            height as u32,
+        );
     }
 }

--- a/src/drawing/backend_impl/bitmap.rs
+++ b/src/drawing/backend_impl/bitmap.rs
@@ -1553,4 +1553,20 @@ mod test {
         }
         checked_save_file("test_series_labels", &buffer, width, height);
     }
+
+    #[test]
+    fn test_draw_pixel_alphas() {
+        let (width, height) = (100_i32, 100_i32);
+        let mut buffer = vec![0; (width * height * 3) as usize];
+        {
+            let root = BitMapBackend::with_buffer(&mut buffer, (width as u32, height as u32))
+                .into_drawing_area();
+            root.fill(&WHITE).unwrap();
+            for i in -20..20 {
+                let alpha = i as f64 * 0.1;
+                root.draw_pixel((50 + i, 50 + i), &BLACK.mix(alpha)).unwrap();
+            }
+        }
+        checked_save_file("test_draw_pixel_alphas", &buffer, width as u32, height as u32);
+    }
 }

--- a/src/drawing/backend_impl/cairo.rs
+++ b/src/drawing/backend_impl/cairo.rs
@@ -534,4 +534,24 @@ mod test {
         let content = String::from_utf8(buffer).unwrap();
         checked_save_file("test_series_labels", &content);
     }
+
+    #[test]
+    fn test_draw_pixel_alphas() {
+        let buffer: Vec<u8> = vec![];
+        let (width, height) = (100_i32, 100_i32);
+        let surface = cairo::PsSurface::for_stream(width.into(), height.into(), buffer);
+        let cr = CairoContext::new(&surface);
+        let root = CairoBackend::new(&cr, (width as u32, height as u32))
+            .unwrap()
+            .into_drawing_area();
+
+        for i in -20..20 {
+            let alpha = i as f64 * 0.1;
+            root.draw_pixel((50 + i, 50 + i), &BLACK.mix(alpha)).unwrap();
+        }
+
+        let buffer = *surface.finish_output_stream().unwrap().downcast().unwrap();
+        let content = String::from_utf8(buffer).unwrap();
+        checked_save_file("test_draw_pixel_alphas", &content);
+    }
 }

--- a/src/drawing/backend_impl/cairo.rs
+++ b/src/drawing/backend_impl/cairo.rs
@@ -386,7 +386,7 @@ mod test {
     #[test]
     fn test_text_draw() {
         let buffer: Vec<u8> = vec![];
-        let (width, height) = (1000, 600);
+        let (width, height) = (1500, 800);
         let surface = cairo::PsSurface::for_stream(width.into(), height.into(), buffer);
         let cr = CairoContext::new(&surface);
         let root = CairoBackend::new(&cr, (width, height))
@@ -411,6 +411,8 @@ mod test {
             .draw()
             .unwrap();
 
+        let ((x1, y1), (x2, y2), (x3, y3)) = ((-30, 30), (0, -30), (30, 30));
+
         for (dy, trans) in [
             FontTransform::None,
             FontTransform::Rotate90,
@@ -422,13 +424,18 @@ mod test {
         {
             for (dx1, h_pos) in [HPos::Left, HPos::Right, HPos::Center].iter().enumerate() {
                 for (dx2, v_pos) in [VPos::Top, VPos::Center, VPos::Bottom].iter().enumerate() {
-                    let x = 100_i32 + (dx1 as i32 * 3 + dx2 as i32) * 100;
-                    let y = 100 + dy as i32 * 100;
-                    root.draw(&Circle::new((x, y), 3, &BLACK.mix(0.5))).unwrap();
-                    let style = TextStyle::from(("sans-serif", 20).into_font())
-                        .pos(Pos::new(*h_pos, *v_pos))
-                        .transform(trans.clone());
-                    root.draw_text("test", &style, (x, y)).unwrap();
+                    let x = 150_i32 + (dx1 as i32 * 3 + dx2 as i32) * 150;
+                    let y = 120 + dy as i32 * 150;
+                    let draw = |x, y, text| {
+                        root.draw(&Circle::new((x, y), 3, &BLACK.mix(0.5))).unwrap();
+                        let style = TextStyle::from(("sans-serif", 20).into_font())
+                            .pos(Pos::new(*h_pos, *v_pos))
+                            .transform(trans.clone());
+                        root.draw_text(text, &style, (x, y)).unwrap();
+                    };
+                    draw(x + x1, y + y1, "dood");
+                    draw(x + x2, y + y2, "dog");
+                    draw(x + x3, y + y3, "goog");
                 }
             }
         }
@@ -437,7 +444,9 @@ mod test {
         let content = String::from_utf8(buffer).unwrap();
         checked_save_file("test_text_draw", &content);
 
-        assert_eq!(content.matches("test").count(), 36);
+        assert_eq!(content.matches("dog").count(), 36);
+        assert_eq!(content.matches("dood").count(), 36);
+        assert_eq!(content.matches("goog").count(), 36);
     }
 
     #[test]
@@ -547,7 +556,8 @@ mod test {
 
         for i in -20..20 {
             let alpha = i as f64 * 0.1;
-            root.draw_pixel((50 + i, 50 + i), &BLACK.mix(alpha)).unwrap();
+            root.draw_pixel((50 + i, 50 + i), &BLACK.mix(alpha))
+                .unwrap();
         }
 
         let buffer = *surface.finish_output_stream().unwrap().downcast().unwrap();

--- a/src/drawing/backend_impl/cairo.rs
+++ b/src/drawing/backend_impl/cairo.rs
@@ -2,8 +2,9 @@ use cairo::{Context as CairoContext, FontSlant, FontWeight, Status as CairoStatu
 
 #[allow(unused_imports)]
 use crate::drawing::backend::{BackendCoord, BackendStyle, DrawingBackend, DrawingErrorKind};
+use crate::style::text_anchor::{HPos, VPos};
 #[allow(unused_imports)]
-use crate::style::{Color, FontStyle, FontTransform, RGBAColor, TextStyle};
+use crate::style::{Color, FontDesc, FontStyle, FontTransform, RGBAColor, TextStyle};
 
 /// The drawing backend that is backed with a Cairo context
 pub struct CairoBackend<'a> {
@@ -25,14 +26,28 @@ impl std::fmt::Display for CairoError {
 impl std::error::Error for CairoError {}
 
 impl<'a> CairoBackend<'a> {
-    fn call_cairo<F: Fn(&CairoContext)>(&self, f: F) -> Result<(), DrawingErrorKind<CairoError>> {
-        f(self.context);
-        if self.context.status() == CairoStatus::Success {
-            return Ok(());
+    /// Call cairo functions and verify the cairo status afterward.
+    ///
+    /// All major cairo objects retain an error status internally
+    /// which can be queried anytime by the users using status() method.
+    /// In the mean time, it is safe to call all cairo functions normally even
+    /// if the underlying object is in an error status.
+    /// This means that no error handling code is required before or after
+    /// each individual cairo function call.
+    ///
+    /// - `f`: The function to call
+    /// - *Returns* The wrapped result of the function
+    fn call_cairo<T, F: Fn(&CairoContext) -> T>(
+        &self,
+        f: F,
+    ) -> Result<T, DrawingErrorKind<CairoError>> {
+        let result = f(self.context);
+        let status = self.context.status();
+        if status == CairoStatus::Success {
+            Ok(result)
+        } else {
+            Err(DrawingErrorKind::DrawingError(CairoError(status)))
         }
-        Err(DrawingErrorKind::DrawingError(CairoError(
-            self.context.status(),
-        )))
     }
 
     fn set_color(&self, color: &RGBAColor) -> Result<(), DrawingErrorKind<CairoError>> {
@@ -43,13 +58,32 @@ impl<'a> CairoBackend<'a> {
                 f64::from(color.rgb().2) / 255.0,
                 f64::from(color.alpha()),
             )
-        })?;
-        Ok(())
+        })
     }
 
     fn set_stroke_width(&self, width: u32) -> Result<(), DrawingErrorKind<CairoError>> {
-        self.call_cairo(|c| c.set_line_width(f64::from(width)))?;
-        Ok(())
+        self.call_cairo(|c| c.set_line_width(f64::from(width)))
+    }
+
+    fn set_font<'b>(&self, font: &FontDesc<'b>) -> Result<(), DrawingErrorKind<CairoError>> {
+        let actual_size = font.get_size();
+        self.call_cairo(|c| {
+            match font.get_style() {
+                FontStyle::Normal => {
+                    c.select_font_face(font.get_name(), FontSlant::Normal, FontWeight::Normal)
+                }
+                FontStyle::Bold => {
+                    c.select_font_face(font.get_name(), FontSlant::Normal, FontWeight::Bold)
+                }
+                FontStyle::Oblique => {
+                    c.select_font_face(font.get_name(), FontSlant::Oblique, FontWeight::Normal)
+                }
+                FontStyle::Italic => {
+                    c.select_font_face(font.get_name(), FontSlant::Italic, FontWeight::Normal)
+                }
+            };
+            c.set_font_size(actual_size);
+        })
     }
 
     pub fn new(context: &'a CairoContext, (w, h): (u32, u32)) -> Result<Self, CairoError> {
@@ -72,8 +106,8 @@ impl<'a> DrawingBackend for CairoBackend<'a> {
 
     fn ensure_prepared(&mut self) -> Result<(), DrawingErrorKind<Self::ErrorType>> {
         if !self.init_flag {
-            let (x0, y0, x1, y1) = self.context.clip_extents();
             self.call_cairo(|c| {
+                let (x0, y0, x1, y1) = c.clip_extents();
                 c.scale(
                     (x1 - x0) / f64::from(self.width),
                     (y1 - y0) / f64::from(self.height),
@@ -93,17 +127,16 @@ impl<'a> DrawingBackend for CairoBackend<'a> {
         point: BackendCoord,
         color: &RGBAColor,
     ) -> Result<(), DrawingErrorKind<Self::ErrorType>> {
-        self.call_cairo(|c| c.rectangle(f64::from(point.0), f64::from(point.1), 1.0, 1.0))?;
         self.call_cairo(|c| {
+            c.rectangle(f64::from(point.0), f64::from(point.1), 1.0, 1.0);
             c.set_source_rgba(
                 f64::from(color.rgb().0) / 255.0,
                 f64::from(color.rgb().1) / 255.0,
                 f64::from(color.rgb().2) / 255.0,
                 f64::from(color.alpha()),
-            )
-        })?;
-        self.call_cairo(|c| c.fill())?;
-        Ok(())
+            );
+            c.fill();
+        })
     }
 
     fn draw_line<S: BackendStyle>(
@@ -112,14 +145,14 @@ impl<'a> DrawingBackend for CairoBackend<'a> {
         to: BackendCoord,
         style: &S,
     ) -> Result<(), DrawingErrorKind<Self::ErrorType>> {
-        self.call_cairo(|c| c.move_to(f64::from(from.0), f64::from(from.1)))?;
-
         self.set_color(&style.as_color())?;
         self.set_stroke_width(style.stroke_width())?;
 
-        self.call_cairo(|c| c.line_to(f64::from(to.0), f64::from(to.1)))?;
-        self.call_cairo(|c| c.stroke())?;
-        Ok(())
+        self.call_cairo(|c| {
+            c.move_to(f64::from(from.0), f64::from(from.1));
+            c.line_to(f64::from(to.0), f64::from(to.1));
+            c.stroke();
+        })
     }
 
     fn draw_rect<S: BackendStyle>(
@@ -138,16 +171,13 @@ impl<'a> DrawingBackend for CairoBackend<'a> {
                 f64::from(upper_left.1),
                 f64::from(bottom_right.0 - upper_left.0),
                 f64::from(bottom_right.1 - upper_left.1),
-            )
-        })?;
-
-        if fill {
-            self.call_cairo(|c| c.fill())?;
-        } else {
-            self.call_cairo(|c| c.stroke())?;
-        }
-
-        Ok(())
+            );
+            if fill {
+                c.fill();
+            } else {
+                c.stroke();
+            }
+        })
     }
 
     fn draw_path<S: BackendStyle, I: IntoIterator<Item = BackendCoord>>(
@@ -159,7 +189,6 @@ impl<'a> DrawingBackend for CairoBackend<'a> {
         self.set_stroke_width(style.stroke_width())?;
 
         let mut path = path.into_iter();
-
         if let Some((x, y)) = path.next() {
             self.call_cairo(|c| c.move_to(f64::from(x), f64::from(y)))?;
         }
@@ -168,9 +197,7 @@ impl<'a> DrawingBackend for CairoBackend<'a> {
             self.call_cairo(|c| c.line_to(f64::from(x), f64::from(y)))?;
         }
 
-        self.call_cairo(|c| c.stroke())?;
-
-        Ok(())
+        self.call_cairo(|c| c.stroke())
     }
 
     fn fill_polygon<S: BackendStyle, I: IntoIterator<Item = BackendCoord>>(
@@ -185,18 +212,18 @@ impl<'a> DrawingBackend for CairoBackend<'a> {
 
         if let Some((x, y)) = path.next() {
             self.call_cairo(|c| c.move_to(f64::from(x), f64::from(y)))?;
+
+            for (x, y) in path {
+                self.call_cairo(|c| c.line_to(f64::from(x), f64::from(y)))?;
+            }
+
+            self.call_cairo(|c| {
+                c.close_path();
+                c.fill();
+            })
         } else {
-            return Ok(());
+            Ok(())
         }
-
-        for (x, y) in path {
-            self.call_cairo(|c| c.line_to(f64::from(x), f64::from(y)))?;
-        }
-
-        self.call_cairo(|c| c.close_path())?;
-        self.call_cairo(|c| c.fill())?;
-
-        Ok(())
     }
 
     fn draw_circle<S: BackendStyle>(
@@ -210,21 +237,33 @@ impl<'a> DrawingBackend for CairoBackend<'a> {
         self.set_stroke_width(style.stroke_width())?;
 
         self.call_cairo(|c| {
+            c.new_sub_path();
             c.arc(
                 f64::from(center.0),
                 f64::from(center.1),
                 f64::from(radius),
                 0.0,
                 std::f64::consts::PI * 2.0,
-            )
-        })?;
+            );
 
-        if fill {
-            self.call_cairo(|c| c.fill())?;
-        } else {
-            self.call_cairo(|c| c.stroke())?;
-        }
-        Ok(())
+            if fill {
+                c.fill();
+            } else {
+                c.stroke();
+            }
+        })
+    }
+
+    fn estimate_text_size<'b>(
+        &self,
+        text: &str,
+        font: &FontDesc<'b>,
+    ) -> Result<(u32, u32), DrawingErrorKind<Self::ErrorType>> {
+        self.set_font(&font)?;
+        self.call_cairo(|c| {
+            let extents = c.text_extents(text);
+            (extents.width as u32, extents.height as u32)
+        })
     }
 
     fn draw_text(
@@ -245,41 +284,38 @@ impl<'a> DrawingBackend for CairoBackend<'a> {
         } / 180.0
             * std::f64::consts::PI;
 
-        let layout = font.layout_box(text).map_err(DrawingErrorKind::FontError)?;
-
         if degree != 0.0 {
-            self.call_cairo(|c| c.save())?;
-            let offset = font.get_transform().offset(layout);
-            self.call_cairo(|c| c.translate(f64::from(x + offset.0), f64::from(y + offset.1)))?;
-            self.call_cairo(|c| c.rotate(degree))?;
+            self.call_cairo(|c| {
+                c.save();
+                c.translate(f64::from(x), f64::from(y));
+                c.rotate(degree);
+            })?;
             x = 0;
             y = 0;
         }
 
-        self.call_cairo(|c| match font.get_style() {
-            FontStyle::Normal => {
-                c.select_font_face(font.get_name(), FontSlant::Normal, FontWeight::Normal)
-            }
-            FontStyle::Bold => {
-                c.select_font_face(font.get_name(), FontSlant::Normal, FontWeight::Bold)
-            }
-            FontStyle::Oblique => {
-                c.select_font_face(font.get_name(), FontSlant::Oblique, FontWeight::Normal)
-            }
-            FontStyle::Italic => {
-                c.select_font_face(font.get_name(), FontSlant::Italic, FontWeight::Normal)
-            }
-        })?;
-        let actual_size = font.get_size();
-        self.call_cairo(|c| c.set_font_size(actual_size))?;
+        self.set_font(&font)?;
         self.set_color(&color)?;
-        self.call_cairo(|c| c.move_to(f64::from(x), f64::from(y - (layout.0).1)))?;
-        self.call_cairo(|c| c.show_text(text))?;
 
-        if degree != 0.0 {
-            self.call_cairo(|c| c.restore())?;
-        }
-        Ok(())
+        let (width, height) = self.estimate_text_size(text, &style.font)?;
+        let (width, height) = (width as f64, height as f64);
+        self.call_cairo(|c| {
+            let dx = match style.pos.h_pos {
+                HPos::Left => 0.0,
+                HPos::Right => -width,
+                HPos::Center => -width / 2.0,
+            };
+            let dy = match style.pos.v_pos {
+                VPos::Top => height,
+                VPos::Center => height / 2.0,
+                VPos::Bottom => 0.0,
+            };
+            c.move_to(f64::from(x) + dx, f64::from(y) + dy);
+            c.show_text(text);
+            if degree != 0.0 {
+                c.restore();
+            }
+        })
     }
 }
 
@@ -287,44 +323,210 @@ impl<'a> DrawingBackend for CairoBackend<'a> {
 mod test {
     use super::*;
     use crate::prelude::*;
+    use crate::style::text_anchor::{HPos, Pos, VPos};
     use std::fs;
     use std::path::Path;
 
     static DST_DIR: &str = "target/test/cairo";
 
-    #[test]
-    fn test_draw_mesh() {
+    fn checked_save_file(name: &str, content: &str) {
+        /*
+          Please use the PS file to manually verify the results.
+
+          You may want to use Ghostscript to view the file.
+        */
+        assert!(!content.is_empty());
+        fs::create_dir_all(DST_DIR).unwrap();
+        let file_name = format!("{}.ps", name);
+        let file_path = Path::new(DST_DIR).join(file_name);
+        println!("{:?} created", file_path);
+        fs::write(file_path, &content).unwrap();
+    }
+
+    fn draw_mesh_with_custom_ticks(tick_size: i32, test_name: &str) {
         let buffer: Vec<u8> = vec![];
-        let surface = cairo::PsSurface::for_stream(1024.0, 768.0, buffer);
+        let surface = cairo::PsSurface::for_stream(500.0, 500.0, buffer);
         let cr = CairoContext::new(&surface);
         let root = CairoBackend::new(&cr, (500, 500))
             .unwrap()
             .into_drawing_area();
-        root.fill(&WHITE).unwrap();
 
         // Text could be rendered to different elements if has whitespaces
         let mut chart = ChartBuilder::on(&root)
             .caption("this-is-a-test", ("sans-serif", 20))
-            .x_label_area_size(40)
-            .y_label_area_size(40)
-            .build_ranged(0..100, 0..100)
+            .set_all_label_area_size(40)
+            .build_ranged(0..10, 0..10)
             .unwrap();
 
-        chart.configure_mesh().draw().unwrap();
+        chart
+            .configure_mesh()
+            .set_all_tick_mark_size(tick_size)
+            .draw()
+            .unwrap();
 
         let buffer = *surface.finish_output_stream().unwrap().downcast().unwrap();
         let content = String::from_utf8(buffer).unwrap();
+        checked_save_file(test_name, &content);
 
-        /*
-          Please use the PS file to manually verify the results.
+        assert!(content.contains("this-is-a-test"));
+    }
 
-          You may want to use `ps2pdf` to get the readable PDF file.
-        */
-        fs::create_dir_all(DST_DIR).unwrap();
-        let file_path = Path::new(DST_DIR).join("test_draw_mesh.ps");
-        println!("{:?} created", file_path);
-        fs::write(file_path, &content).unwrap();
+    #[test]
+    fn test_draw_mesh_no_ticks() {
+        draw_mesh_with_custom_ticks(0, "test_draw_mesh_no_ticks");
+    }
 
-        //assert!(content.contains("this-is-a-test"));
+    #[test]
+    fn test_draw_mesh_negative_ticks() {
+        draw_mesh_with_custom_ticks(-10, "test_draw_mesh_negative_ticks");
+    }
+
+    #[test]
+    fn test_text_draw() {
+        let buffer: Vec<u8> = vec![];
+        let (width, height) = (1000, 500);
+        let surface = cairo::PsSurface::for_stream(width.into(), height.into(), buffer);
+        let cr = CairoContext::new(&surface);
+        let root = CairoBackend::new(&cr, (width, height))
+            .unwrap()
+            .into_drawing_area();
+
+        let mut chart = ChartBuilder::on(&root)
+            .caption("All anchor point positions", ("sans-serif", 20))
+            .set_all_label_area_size(40)
+            .build_ranged(0..100, 0..50)
+            .unwrap();
+
+        chart
+            .configure_mesh()
+            .disable_x_mesh()
+            .disable_y_mesh()
+            .x_desc("X Axis")
+            .y_desc("Y Axis")
+            .draw()
+            .unwrap();
+
+        for (dy, trans) in [
+            FontTransform::None,
+            FontTransform::Rotate90,
+            FontTransform::Rotate180,
+            FontTransform::Rotate270,
+        ]
+        .iter()
+        .enumerate()
+        {
+            for (dx1, h_pos) in [HPos::Left, HPos::Right, HPos::Center].iter().enumerate() {
+                for (dx2, v_pos) in [VPos::Top, VPos::Center, VPos::Bottom].iter().enumerate() {
+                    let x = 100_i32 + (dx1 as i32 * 3 + dx2 as i32) * 100;
+                    let y = 100 + dy as i32 * 100;
+                    root.draw(&Circle::new((x, y), 3, &BLACK.mix(0.5))).unwrap();
+                    let style = TextStyle::from(("sans-serif", 20).into_font())
+                        .pos(Pos::new(*h_pos, *v_pos))
+                        .transform(trans.clone());
+                    root.draw_text("test", &style, (x, y)).unwrap();
+                }
+            }
+        }
+
+        let buffer = *surface.finish_output_stream().unwrap().downcast().unwrap();
+        let content = String::from_utf8(buffer).unwrap();
+        checked_save_file("test_text_draw", &content);
+
+        assert_eq!(content.matches("test").count(), 36);
+    }
+
+    #[test]
+    fn test_text_clipping() {
+        let buffer: Vec<u8> = vec![];
+        let (width, height) = (500_i32, 500_i32);
+        let surface = cairo::PsSurface::for_stream(width.into(), height.into(), buffer);
+        let cr = CairoContext::new(&surface);
+        let root = CairoBackend::new(&cr, (width as u32, height as u32))
+            .unwrap()
+            .into_drawing_area();
+
+        let style = TextStyle::from(("sans-serif", 20).into_font())
+            .pos(Pos::new(HPos::Center, VPos::Center));
+        root.draw_text("TOP LEFT", &style, (0, 0)).unwrap();
+        root.draw_text("TOP CENTER", &style, (width / 2, 0))
+            .unwrap();
+        root.draw_text("TOP RIGHT", &style, (width, 0)).unwrap();
+
+        root.draw_text("MIDDLE LEFT", &style, (0, height / 2))
+            .unwrap();
+        root.draw_text("MIDDLE RIGHT", &style, (width, height / 2))
+            .unwrap();
+
+        root.draw_text("BOTTOM LEFT", &style, (0, height)).unwrap();
+        root.draw_text("BOTTOM CENTER", &style, (width / 2, height))
+            .unwrap();
+        root.draw_text("BOTTOM RIGHT", &style, (width, height))
+            .unwrap();
+
+        let buffer = *surface.finish_output_stream().unwrap().downcast().unwrap();
+        let content = String::from_utf8(buffer).unwrap();
+        checked_save_file("test_text_clipping", &content);
+    }
+
+    #[test]
+    fn test_series_labels() {
+        let buffer: Vec<u8> = vec![];
+        let (width, height) = (500, 500);
+        let surface = cairo::PsSurface::for_stream(width.into(), height.into(), buffer);
+        let cr = CairoContext::new(&surface);
+        let root = CairoBackend::new(&cr, (width, height))
+            .unwrap()
+            .into_drawing_area();
+
+        let mut chart = ChartBuilder::on(&root)
+            .caption("All series label positions", ("sans-serif", 20))
+            .set_all_label_area_size(40)
+            .build_ranged(0..50, 0..50)
+            .unwrap();
+
+        chart
+            .configure_mesh()
+            .disable_x_mesh()
+            .disable_y_mesh()
+            .draw()
+            .unwrap();
+
+        chart
+            .draw_series(std::iter::once(Circle::new((5, 15), 5, &RED)))
+            .expect("Drawing error")
+            .label("Series 1")
+            .legend(|(x, y)| Circle::new((x, y), 3, RED.filled()));
+
+        chart
+            .draw_series(std::iter::once(Circle::new((5, 15), 10, &BLUE)))
+            .expect("Drawing error")
+            .label("Series 2")
+            .legend(|(x, y)| Circle::new((x, y), 3, BLUE.filled()));
+
+        for pos in vec![
+            SeriesLabelPosition::UpperLeft,
+            SeriesLabelPosition::MiddleLeft,
+            SeriesLabelPosition::LowerLeft,
+            SeriesLabelPosition::UpperMiddle,
+            SeriesLabelPosition::MiddleMiddle,
+            SeriesLabelPosition::LowerMiddle,
+            SeriesLabelPosition::UpperRight,
+            SeriesLabelPosition::MiddleRight,
+            SeriesLabelPosition::LowerRight,
+            SeriesLabelPosition::Coordinate(70, 70),
+        ]
+        .into_iter()
+        {
+            chart
+                .configure_series_labels()
+                .border_style(&BLACK.mix(0.5))
+                .position(pos)
+                .draw()
+                .expect("Drawing error");
+        }
+
+        let buffer = *surface.finish_output_stream().unwrap().downcast().unwrap();
+        let content = String::from_utf8(buffer).unwrap();
+        checked_save_file("test_series_labels", &content);
     }
 }

--- a/src/drawing/backend_impl/canvas.rs
+++ b/src/drawing/backend_impl/canvas.rs
@@ -365,7 +365,7 @@ mod test {
     #[wasm_bindgen_test]
     fn test_text_draw() {
         let document = window().unwrap().document().unwrap();
-        let canvas = create_canvas(&document, "test_text_draw", 1000, 600);
+        let canvas = create_canvas(&document, "test_text_draw", 1500, 800);
         let backend = CanvasBackend::with_canvas_object(canvas).expect("cannot find canvas");
         let root = backend.into_drawing_area();
         let root = root
@@ -387,6 +387,8 @@ mod test {
             .draw()
             .unwrap();
 
+        let ((x1, y1), (x2, y2), (x3, y3)) = ((-30, 30), (0, -30), (30, 30));
+
         for (dy, trans) in [
             FontTransform::None,
             FontTransform::Rotate90,
@@ -398,13 +400,18 @@ mod test {
         {
             for (dx1, h_pos) in [HPos::Left, HPos::Right, HPos::Center].iter().enumerate() {
                 for (dx2, v_pos) in [VPos::Top, VPos::Center, VPos::Bottom].iter().enumerate() {
-                    let x = 100_i32 + (dx1 as i32 * 3 + dx2 as i32) * 100;
-                    let y = 100 + dy as i32 * 100;
-                    root.draw(&Circle::new((x, y), 3, &BLACK.mix(0.5))).unwrap();
-                    let style = TextStyle::from(("sans-serif", 20).into_font())
-                        .pos(Pos::new(*h_pos, *v_pos))
-                        .transform(trans.clone());
-                    root.draw_text("test", &style, (x, y)).unwrap();
+                    let x = 150_i32 + (dx1 as i32 * 3 + dx2 as i32) * 150;
+                    let y = 120 + dy as i32 * 150;
+                    let draw = |x, y, text| {
+                        root.draw(&Circle::new((x, y), 3, &BLACK.mix(0.5))).unwrap();
+                        let style = TextStyle::from(("sans-serif", 20).into_font())
+                            .pos(Pos::new(*h_pos, *v_pos))
+                            .transform(trans.clone());
+                        root.draw_text(text, &style, (x, y)).unwrap();
+                    };
+                    draw(x + x1, y + y1, "dood");
+                    draw(x + x2, y + y2, "dog");
+                    draw(x + x3, y + y3, "goog");
                 }
             }
         }
@@ -502,13 +509,19 @@ mod test {
     fn test_draw_pixel_alphas() {
         let (width, height) = (100_i32, 100_i32);
         let document = window().unwrap().document().unwrap();
-        let canvas = create_canvas(&document, "test_draw_pixel_alphas", width as u32, height as u32);
+        let canvas = create_canvas(
+            &document,
+            "test_draw_pixel_alphas",
+            width as u32,
+            height as u32,
+        );
         let backend = CanvasBackend::with_canvas_object(canvas).expect("cannot find canvas");
         let root = backend.into_drawing_area();
 
         for i in -20..20 {
             let alpha = i as f64 * 0.1;
-            root.draw_pixel((50 + i, 50 + i), &BLACK.mix(alpha)).unwrap();
+            root.draw_pixel((50 + i, 50 + i), &BLACK.mix(alpha))
+                .unwrap();
         }
 
         check_content(&document, "test_draw_pixel_alphas");

--- a/src/drawing/backend_impl/canvas.rs
+++ b/src/drawing/backend_impl/canvas.rs
@@ -365,9 +365,12 @@ mod test {
     #[wasm_bindgen_test]
     fn test_text_draw() {
         let document = window().unwrap().document().unwrap();
-        let canvas = create_canvas(&document, "test_text_draw", 1000, 500);
+        let canvas = create_canvas(&document, "test_text_draw", 1000, 600);
         let backend = CanvasBackend::with_canvas_object(canvas).expect("cannot find canvas");
         let root = backend.into_drawing_area();
+        let root = root
+            .titled("Image Title", ("sans-serif", 60).into_font())
+            .unwrap();
 
         let mut chart = ChartBuilder::on(&root)
             .caption("All anchor point positions", ("sans-serif", 20))

--- a/src/drawing/backend_impl/canvas.rs
+++ b/src/drawing/backend_impl/canvas.rs
@@ -497,4 +497,20 @@ mod test {
 
         check_content(&document, "test_series_labels");
     }
+
+    #[wasm_bindgen_test]
+    fn test_draw_pixel_alphas() {
+        let (width, height) = (100_i32, 100_i32);
+        let document = window().unwrap().document().unwrap();
+        let canvas = create_canvas(&document, "test_draw_pixel_alphas", width as u32, height as u32);
+        let backend = CanvasBackend::with_canvas_object(canvas).expect("cannot find canvas");
+        let root = backend.into_drawing_area();
+
+        for i in -20..20 {
+            let alpha = i as f64 * 0.1;
+            root.draw_pixel((50 + i, 50 + i), &BLACK.mix(alpha)).unwrap();
+        }
+
+        check_content(&document, "test_draw_pixel_alphas");
+    }
 }

--- a/src/drawing/backend_impl/svg.rs
+++ b/src/drawing/backend_impl/svg.rs
@@ -634,4 +634,23 @@ mod test {
         let content = String::from_utf8(buffer).unwrap();
         checked_save_file("test_series_labels", &content);
     }
+
+    #[test]
+    fn test_draw_pixel_alphas() {
+        let mut buffer: Vec<u8> = vec![];
+        {
+            let (width, height) = (100_i32, 100_i32);
+            let root = SVGBackend::with_buffer(&mut buffer, (width as u32, height as u32))
+                .into_drawing_area();
+            root.fill(&WHITE).unwrap();
+
+            for i in -20..20 {
+                let alpha = i as f64 * 0.1;
+                root.draw_pixel((50 + i, 50 + i), &BLACK.mix(alpha)).unwrap();
+            }
+        }
+
+        let content = String::from_utf8(buffer).unwrap();
+        checked_save_file("test_draw_pixel_alphas", &content);
+    }
 }

--- a/src/drawing/backend_impl/svg.rs
+++ b/src/drawing/backend_impl/svg.rs
@@ -484,7 +484,10 @@ mod test {
     fn test_text_draw() {
         let mut buffer: Vec<u8> = vec![];
         {
-            let root = SVGBackend::with_buffer(&mut buffer, (1000, 500)).into_drawing_area();
+            let root = SVGBackend::with_buffer(&mut buffer, (1000, 600)).into_drawing_area();
+            let root = root
+                .titled("Image Title", ("sans-serif", 60).into_font())
+                .unwrap();
 
             let mut chart = ChartBuilder::on(&root)
                 .caption("All anchor point positions", ("sans-serif", 20))

--- a/src/style/font/font_desc.rs
+++ b/src/style/font/font_desc.rs
@@ -1,5 +1,6 @@
 use super::{FontData, FontDataInternal};
-use crate::style::{Color, LayoutBox, TextAlignment, TextStyle};
+use crate::style::text_anchor::Pos;
+use crate::style::{Color, LayoutBox, TextStyle};
 
 use std::convert::From;
 
@@ -255,7 +256,7 @@ impl<'a> FontDesc<'a> {
         TextStyle {
             font: self.clone(),
             color: color.to_rgba(),
-            alignment: TextAlignment::Left,
+            pos: Pos::default(),
         }
     }
 
@@ -302,7 +303,7 @@ impl<'a> FontDesc<'a> {
         draw: DrawFunc,
     ) -> FontResult<Result<(), E>> {
         match &self.data {
-            Ok(ref font) => font.draw((x, y), self.size, text, self.get_transform(), draw),
+            Ok(ref font) => font.draw((x, y), self.size, text, draw),
             Err(e) => Err(e.clone()),
         }
     }

--- a/src/style/font/font_desc.rs
+++ b/src/style/font/font_desc.rs
@@ -1,6 +1,6 @@
 use super::{FontData, FontDataInternal};
 use crate::style::text_anchor::Pos;
-use crate::style::{Color, LayoutBox, TextStyle};
+use crate::style::{Color, TextStyle};
 
 use std::convert::From;
 
@@ -24,20 +24,6 @@ pub enum FontTransform {
 }
 
 impl FontTransform {
-    /// Compute the offset of the "top-left" corner of the text.
-    /// "Top-left" defined as the first char's top-left in reading orientation.
-    ///
-    /// - `layout`: The bouncing box of the text
-    /// - **returns**: The offset in pixels
-    pub fn offset(&self, layout: LayoutBox) -> (i32, i32) {
-        match self {
-            FontTransform::None => (0, 0),
-            FontTransform::Rotate90 => ((layout.1).1 - (layout.0).1, 0),
-            FontTransform::Rotate180 => ((layout.1).0 - (layout.0).0, (layout.1).1 - (layout.0).1),
-            FontTransform::Rotate270 => (0, (layout.1).0 - (layout.0).0),
-        }
-    }
-
     /// Transform the coordinate to perform the rotation
     ///
     /// - `x`: The x coordinate in pixels before transform

--- a/src/style/font/mod.rs
+++ b/src/style/font/mod.rs
@@ -35,9 +35,8 @@ pub trait FontData: Clone {
         _pos: (i32, i32),
         _size: f64,
         _text: &str,
-        _trans: FontTransform,
         _draw: DrawFunc,
     ) -> Result<Result<(), E>, Self::ErrorType> {
-        panic!("The font implementation is unable to draw font");
+        panic!("The font implementation is unable to draw text");
     }
 }

--- a/src/style/font/ttf.rs
+++ b/src/style/font/ttf.rs
@@ -141,14 +141,14 @@ impl FontData for FontDataInternal {
 
         let font = &self.0;
 
-        font.layout(text, scale, point(0.0, 0.0)).for_each(|g| {
+        for g in font.layout(text, scale, point(0.0, 0.0)) {
             if let Some(rect) = g.pixel_bounding_box() {
                 min_x = min_x.min(rect.min.x);
                 min_y = min_y.min(rect.min.y);
                 max_x = max_x.max(rect.max.x);
                 max_y = max_y.max(rect.max.y);
             }
-        });
+        }
 
         if min_x == i32::MAX || min_y == i32::MAX {
             return Ok(((0, 0), (0, 0)));

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -21,4 +21,5 @@ pub use font::{
 };
 pub use shape::ShapeStyle;
 pub use size::{AsRelative, RelativeSize, SizeDesc};
-pub use text::{IntoTextStyle, TextAlignment, TextStyle};
+pub use text::text_anchor;
+pub use text::{IntoTextStyle, TextStyle};


### PR DESCRIPTION
A follow-up PR regarding text alignment. The main change is a new attribute added to the `TextStyle` - the text anchor position that specifies the position of the anchor point (used in `draw_text`) relative to the text itself. I had to dismiss my original idea to use rectangles as there is a `Text` element that is a `Drawable`, therefore need to draw itself using specified points. As a bonus, the current implementation is backward compatible.

Unfortunately, completely get rid of the text size estimation isn't possible yet, therefore there are the use-cases there the text won't be properly aligned yet:
- title as it uses the text height to adjust the drawing area;
- series labels as they need to calculate the bound rectangle;
- multiline text. The current implementation is not quite compatible with the client side rendering as rather the backend should calculate its layout, not the element itself (for example, SVG would need to utilize `<tspan>` tag for that).

However, it doesn't affect the actual visible results so much (unless series labels border is visible) as all of those elements utilize the margins.

Additional notes:
- Now backends do all text transformations, no fonts themselves (as a side effect, the font `draw` code is much simpler now as no offsets calculations are needed). It affect multiline element rendering if rotated, however, it doesn't properly rotate even in the original code;
- `should_draw` check is gone from axis drawing as we can't reliable determine the text bounds, so we utilize clipping for that now (verified and fixed for all backends). Also I guess that users prefer partially visible text than completely hidden. However, it would be nice to have support for mesh margins, so we could put some extra spacing thus avoiding clipping;
- the rendering results changed for all examples, so I guess they need to be updated;
- SVG for MS IE/Current Edge has issues because they don't support all tags from the spec. However, as Edge is switching to Chromium rendering engine, it won't be an issue in near future (I've verified with beta Edge). If it could be an issue, I can try to find some workarounds;
- fixed `draw_pixel` in `bitmap` backend to normalize alpha as the `animation` example send overflowed float values to it.
- `console` example have a gap now between bottom labels and the axis, but it's not because of the miscalculations, but rather because ticks are not drawn there (the `draw_line` function doesn't draw vertical lines with 1 `pixel` width).