### PR TITLE
Fix panic in drop

### DIFF
--- a/src/drawing/backend_impl/bitmap.rs
+++ b/src/drawing/backend_impl/bitmap.rs
@@ -998,7 +998,8 @@ impl<'a, P: PixelFormat> DrawingBackend for BitMapBackend<'a, P> {
 impl<P: PixelFormat> Drop for BitMapBackend<'_, P> {
     fn drop(&mut self) {
         if !self.saved {
-            self.present().expect("Unable to save the bitmap");
+            // drop should not panic, so we ignore a failed present
+            let _ = self.present();
         }
     }
 }

--- a/src/drawing/backend_impl/svg.rs
+++ b/src/drawing/backend_impl/svg.rs
@@ -565,7 +565,8 @@ impl<'a> DrawingBackend for SVGBackend<'a> {
 impl Drop for SVGBackend<'_> {
     fn drop(&mut self) {
         if !self.saved {
-            self.present().expect("Unable to save the SVG image");
+            // drop should not panic, so we ignore a failed present
+            let _ = self.present();
         }
     }
 }


### PR DESCRIPTION
If drop has panic, we can't handle error because panic in drop becomes abort.
