### PR TITLE
call npm install

### DIFF
--- a/examples/wasm-demo/start-server.bat
+++ b/examples/wasm-demo/start-server.bat
@@ -4,5 +4,5 @@ wasm-pack build --release
 if errorlevel 1 cargo install wasm-pack
 wasm-pack build --release
 cd www
-npm install
+call npm install
 npm start


### PR DESCRIPTION
call npm install because otherwise it stops there and doesn't execute `npm start`