### PR TITLE
avoid crash and provide a simple solution for very small log scales

### DIFF
--- a/src/coord/logarithmic.rs
+++ b/src/coord/logarithmic.rs
@@ -92,6 +92,13 @@ impl<V: LogScalable> Ranged for LogCoord<V> {
             .log10()
             .abs()
             .floor() as usize;
+        if tier_1 == 0 {
+            let from = self.logic.start.as_f64().floor() as i32;
+            let to = self.logic.end.as_f64().ceil() as i32;
+            let mut ret = vec![];
+            { from..=to }.for_each(|i| ret.push(V::from_f64(f64::from(i))));
+            return ret;
+        }
         let tier_2_density = if max_points < tier_1 {
             0
         } else {


### PR DESCRIPTION
When using a log scale from 2 to 8, plotters crashes as tier_1 is zero and is later used as divisor. I made a simple fix by checking for zero tier_1 and providing a simple scale which iterates the integers between both numbers.

I know this is not a complete fix of the problem, especially as a small scale e.g. 0.2 to 0.8 would not show any grid lines, but the best idea a came up with at the moment and it always prevents the crash.

Sorry I had to close (https://github.com/38/plotters/pull/115) and reopen the pull request, but I did more work and just merging master would be wrong.