### PR TITLE
add readme to explain running examples (closes #125)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,9 @@
+# plotters examples
+
+These are examples of plotters in use! Like in all Rust packages, examples can be built and run with `cargo`.
+
+To run any example, from within the repo, run `cargo run --example <example_name>` where `<example name>` is the name of the file without the `.rs` extension.
+
+The output of these example files are used to generate the [plotters-doc-data](https://github.com/38/plotters-doc-data) repo that populates the beautiful images you see in the main README. For that reason, they must be run with `cargo` from within the repo, or you must change the output filename in the example code to a directory that exists.
+
+The examples that have their own directories and `Cargo.toml` files work differently. They are run the same way you would a standalone project.


### PR DESCRIPTION
Cool package, great work! Hope I can help contribute!

This adds some documentation on how to run the examples and why their directories are what they are (#125). Happy to make any changes you'd like.