### PR TITLE
adjusts html canvas backend size using dpr

### DIFF
--- a/src/drawing/backend_impl/canvas.rs
+++ b/src/drawing/backend_impl/canvas.rs
@@ -74,10 +74,11 @@ impl DrawingBackend for CanvasBackend {
 
     fn get_size(&self) -> (u32, u32) {
         // Getting just canvas.width gives poor results on HighDPI screens.
-        let window = window()?;
+        let window = window().unwrap();
         let mut dpr = window.device_pixel_ratio();
-        dpr = if dpr == 0 { 1 } else { dpr };
-        ((canvas.width() as f64 / dpr) as u32, (canvas.height() as f64 / dpr) as u32)
+        dpr = if dpr == 0.0 { 1.0 } else { dpr };
+        ((self.canvas.width() as f64 / dpr) as u32,
+         (self.canvas.height() as f64 / dpr) as u32)
     }
 
     fn ensure_prepared(&mut self) -> Result<(), DrawingErrorKind<CanvasError>> {

--- a/src/drawing/backend_impl/canvas.rs
+++ b/src/drawing/backend_impl/canvas.rs
@@ -74,8 +74,10 @@ impl DrawingBackend for CanvasBackend {
 
     fn get_size(&self) -> (u32, u32) {
         // Getting just canvas.width gives poor results on HighDPI screens.
-        let rect = self.canvas.get_bounding_client_rect();
-        (rect.width() as u32, rect.height() as u32)
+        let window = window()?;
+        let mut dpr = window.device_pixel_ratio();
+        dpr = if dpr == 0 { 1 } else { dpr };
+        ((canvas.width() as f64 / dpr) as u32, (canvas.height() as f64 / dpr) as u32)
     }
 
     fn ensure_prepared(&mut self) -> Result<(), DrawingErrorKind<CanvasError>> {


### PR DESCRIPTION
Using get_bounding_client_rect to get the html canvas size causes the graph to be incorrectly sized if certain ccs styling is applied to the canvas.  
For example, if you use css to scale a chart, get_bounding_client_rect will return the size to which the canvas will be scaled, not the actual size of the canvas. This causes the plot to be drawn with the wrong dimensions if the css scaling isn't set to the precise values which compensate for the dpr, either clipping off the canvas if it is scaled up, or only taking up part of the canvas if it is scaled down.

To address this issue, I use the device pixel ratio to properly adjust the size of the canvas for high DPI screens.

This is essential for resizing graphs without re-rendering them.