### PR TITLE
Fix pistons scaling of circles

### DIFF
--- a/src/drawing/backend_impl/piston.rs
+++ b/src/drawing/backend_impl/piston.rs
@@ -34,6 +34,14 @@ fn make_point_pair(a: BackendCoord, b: BackendCoord, scale: f64) -> [f64; 4] {
     ]
 }
 
+fn make_circle(center: BackendCoord, radius: u32, scale: f64) -> [f64; 4] {
+    circle(
+        center.0 as f64 * scale,
+        center.1 as f64 * scale,
+        radius as f64 * scale,
+    )
+}
+
 impl<'a, 'b> PistonBackend<'a, 'b> {
     pub fn new(size: (u32, u32), scale: f64, context: Context, graphics: &'b mut G2d<'a>) -> Self {
         Self {
@@ -150,11 +158,7 @@ impl<'a, 'b> DrawingBackend for PistonBackend<'a, 'b> {
         style: &S,
         fill: bool,
     ) -> Result<(), DrawingErrorKind<Self::ErrorType>> {
-        let rect = circle(
-            center.0 as f64 * self.scale,
-            center.1 as f64 * self.scale,
-            radius as f64 * self.scale,
-        );
+        let rect = make_circle(center, radius, self.scale);
         if fill {
             ellipse(
                 make_piston_rgba(&style.as_color()),
@@ -207,4 +211,14 @@ pub fn draw_piston_window<F: FnOnce(PistonBackend) -> Result<(), Box<dyn std::er
         return Some(event);
     }
     None
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn test_make_circle() {
+        assert_eq!(make_circle((1, 1), 0, 1.0), [1.0, 1.0, 0.0, 0.0]);
+        assert_eq!(make_circle((1, 2), 3, 4.0), [-8.0, -4.0, 24.0, 24.0]);
+    }
 }

--- a/src/drawing/backend_impl/piston.rs
+++ b/src/drawing/backend_impl/piston.rs
@@ -150,7 +150,11 @@ impl<'a, 'b> DrawingBackend for PistonBackend<'a, 'b> {
         style: &S,
         fill: bool,
     ) -> Result<(), DrawingErrorKind<Self::ErrorType>> {
-        let rect = circle(center.0 as f64, center.1 as f64, radius as f64);
+        let rect = circle(
+            center.0 as f64 * self.scale,
+            center.1 as f64 * self.scale,
+            radius as f64 * self.scale,
+        );
         if fill {
             ellipse(
                 make_piston_rgba(&style.as_color()),


### PR DESCRIPTION
issue can be easily reproduced by modifying piston-demo example.
```diff
diff --git a/examples/piston-demo/src/main.rs b/examples/piston-demo/src/main.rs
index b58a100..307d71c 100644
--- a/examples/piston-demo/src/main.rs
+++ b/examples/piston-demo/src/main.rs
@@ -58,7 +58,7 @@ fn main() {
             cc.draw_series(LineSeries::new(
                 (0..).zip(data.iter()).map(|(a, b)| (a, *b)),
                 &Palette99::pick(idx),
-            ))?
+            ).point_size(4))?
             .label(format!("CPU {}", idx))
             .legend(move |(x, y)| {
                 Rectangle::new([(x - 5, y - 5), (x + 5, y + 5)], &Palette99::pick(idx))

```
actual result looks like:
![image](https://user-images.githubusercontent.com/41084131/83350916-c022e180-a33f-11ea-8b42-02aeb7953b66.png)
expected result is something like:
![image](https://user-images.githubusercontent.com/41084131/83350959-3293c180-a340-11ea-9b91-8a30f695cdc8.png)
