### PR TITLE
Update to rusttype 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ optional = true
 features = ["std"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-rusttype = { version = "0.8.2", optional = true }
+rusttype = { version = "0.9", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 font-kit = { version = "0.7.0", optional = true }
 piston_window = { version = "0.108.0", optional = true }


### PR DESCRIPTION
This adds support for fonts with CFF glyph outlines.