### PR TITLE
HTML5 backend: line width and drawing area size fixes

### DIFF
--- a/src/drawing/backend_impl/canvas.rs
+++ b/src/drawing/backend_impl/canvas.rs
@@ -84,9 +84,10 @@ impl DrawingBackend for CanvasBackend {
         let window = window().unwrap();
         let mut dpr = window.device_pixel_ratio();
         dpr = if dpr == 0.0 { 1.0 } else { dpr };
+        let rect = self.canvas.get_bounding_client_rect();
         (
-            (self.canvas.width() as f64 / dpr) as u32,
-            (self.canvas.height() as f64 / dpr) as u32,
+            (rect.width() as f64 * dpr) as u32,
+            (rect.height() as f64 * dpr) as u32,
         )
     }
 


### PR DESCRIPTION
Fixes the handling of `stroke_width` from [`ShapeStyle`](https://docs.rs/plotters/0.2.15/plotters/style/struct.ShapeStyle.html) when drawing lines in the canvas backend.
Most line-like (line, path, circle, rect) drawing was setting the stroke style, but not the line width (using [`set_line_width`](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.CanvasRenderingContext2d.html#method.set_line_width)). So in these cases, the line width actually used was the default or the value provided in the latest call to the rare functions that actually called `set_line_width`.

- introduced function `set_line_style` for `CanvasBackend` which sets the stroke style and the line width in the context
- now calling that function when needed, *i.e.* in
    - `draw_line`, `draw_path`, and
    - `draw_rect`, `draw_circle` (when not filling)

Fixes device-pixel-ratio/canvas-size problems introduced in https://github.com/38/plotters/commit/1b4e11a11cddded2cbe348826d7da010181640e5#diff-31f17ae10d710e88872f9010d97ec041. I do not understand plotters enough to give a clear explanation of the problem, but my *vague* understanding that is that the current version

- is using the wrong width/height (the ones directly from the canvas instead of using the bounding rectangle)
- is dividing by the DPR instead of multiplying by it

I might be wrong, and/or my fix might not make sense logically. Do let me know if that's the case. What I can say is that the current version looks terrible (very pixelated / not scaled properly) on high (and possibly low) DPI *in my experiments*, which is not the case of the version I am proposing here.