### PR TITLE
Remove references to `build_ranged` in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .margin(5)
         .x_label_area_size(30)
         .y_label_area_size(30)
-        .build_ranged(-1f32..1f32, -0.1f32..1f32)?;
+        .build_cartesian_2d(-1f32..1f32, -0.1f32..1f32)?;
 
     chart.configure_mesh().draw()?;
 
@@ -215,7 +215,7 @@ let figure = evcxr_figure((640, 480), |root| {
         .margin(5)
         .x_label_area_size(30)
         .y_label_area_size(30)
-        .build_ranged(-1f32..1f32, -0.1f32..1f32)?;
+        .build_cartesian_2d(-1f32..1f32, -0.1f32..1f32)?;
 
     chart.configure_mesh().draw()?;
 

--- a/doc-template/examples/quick_start.rs
+++ b/doc-template/examples/quick_start.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .margin(5)
         .x_label_area_size(30)
         .y_label_area_size(30)
-        .build_ranged(-1f32..1f32, -0.1f32..1f32)?;
+        .build_cartesian_2d(-1f32..1f32, -0.1f32..1f32)?;
 
     chart.configure_mesh().draw()?;
 

--- a/doc-template/readme.template.md
+++ b/doc-template/readme.template.md
@@ -68,7 +68,7 @@ let figure = evcxr_figure((640, 480), |root| {
         .margin(5)
         .x_label_area_size(30)
         .y_label_area_size(30)
-        .build_ranged(-1f32..1f32, -0.1f32..1f32)?;
+        .build_cartesian_2d(-1f32..1f32, -0.1f32..1f32)?;
 
     chart.configure_mesh().draw()?;
 

--- a/src/chart/state.rs
+++ b/src/chart/state.rs
@@ -21,7 +21,7 @@ use plotters_backend::DrawingBackend;
 ///    let chart = ChartBuilder::on(&area[0])
 ///        .caption("Incremental Example", ("sans-serif", 20))
 ///        .set_all_label_area_size(30)
-///        .build_ranged(0..10, 0..10)
+///        .build_cartesian_2d(0..10, 0..10)
 ///        .expect("Unable to build ChartContext");
 ///    // Draw the first frame at this point
 ///    area[0].present().expect("Present");

--- a/src/coord/ranged1d/combinators/ckps.rs
+++ b/src/coord/ranged1d/combinators/ckps.rs
@@ -103,7 +103,7 @@ where
     ///let mut buffer = vec![0;1024*768*3];
     /// let root = BitMapBackend::with_buffer(&mut buffer, (1024, 768)).into_drawing_area();
     /// let mut chart = ChartBuilder::on(&root)
-    ///    .build_ranged(
+    ///    .build_cartesian_2d(
     ///        (0..100).with_key_points(vec![1,20,50,90]),   // <= This line will make the plot shows 4 tick marks at 1, 20, 50, 90
     ///        0..10
     /// ).unwrap();
@@ -143,7 +143,7 @@ where
     ///let mut buffer = vec![0;1024*768*3];
     /// let root = BitMapBackend::with_buffer(&mut buffer, (1024, 768)).into_drawing_area();
     /// let mut chart = ChartBuilder::on(&root)
-    ///    .build_ranged(
+    ///    .build_cartesian_2d(
     ///        (0..100).with_key_point_func(|n| (0..100 / n as i32).map(|x| x * 100 / n as i32).collect()),
     ///        0..10
     /// ).unwrap();

--- a/src/coord/ranged1d/combinators/group_by.rs
+++ b/src/coord/ranged1d/combinators/group_by.rs
@@ -18,7 +18,7 @@ use std::ops::Range;
 ///let mut buf = vec![0;1024*768*3];
 ///let area = BitMapBackend::with_buffer(buf.as_mut(), (1024, 768)).into_drawing_area();
 ///let chart = ChartBuilder::on(&area)
-///    .build_ranged((0..100).group_by(7), 0..100)
+///    .build_cartesian_2d((0..100).group_by(7), 0..100)
 ///    .unwrap();
 ///```
 ///

--- a/src/element/mod.rs
+++ b/src/element/mod.rs
@@ -129,7 +129,7 @@
             .x_label_area_size(40)
             .y_label_area_size(40)
             .margin(5)
-            .build_ranged(0..50, 0..10)?;
+            .build_cartesian_2d(0..50, 0..10)?;
 
         chart
             .configure_mesh()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,7 +310,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .margin(5)
         .x_label_area_size(30)
         .y_label_area_size(30)
-        .build_ranged(-1f32..1f32, -0.1f32..1f32)?;
+        .build_cartesian_2d(-1f32..1f32, -0.1f32..1f32)?;
 
     chart.configure_mesh().draw()?;
 
@@ -354,7 +354,7 @@ let figure = evcxr_figure((640, 480), |root| {
         .margin(5)
         .x_label_area_size(30)
         .y_label_area_size(30)
-        .build_ranged(-1f32..1f32, -0.1f32..1f32)?;
+        .build_cartesian_2d(-1f32..1f32, -0.1f32..1f32)?;
 
     chart.configure_mesh().draw()?;
 


### PR DESCRIPTION
Since the function is deprecated, it shouldn't be recommended in
examples. All instances of `build_ranged` have been replaced with the
new `build_cartesian_2d`.