### PR TITLE
Allow passing colors by value and reference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["doc-template/*"]
 [dependencies]
 num-traits = "0.2.11"
 chrono = { version = "0.4.11", optional = true }
-plotters-backend = "^0.3.*"
+plotters-backend = { git = "https://github.com/chrisduerr/plotters-backend", rev = "529f08f3aa5ede8e71950c1a5d3be4683330f549" }
 plotters-svg = {version = "^0.3.*", optional = true}
 
 [dependencies.plotters-bitmap]

--- a/src/style/color.rs
+++ b/src/style/color.rs
@@ -50,9 +50,11 @@ pub trait Color: BackendStyle {
     }
 }
 
+impl<T: Color> Color for &'_ T {}
+
 /// The RGBA representation of the color, Plotters use RGBA as the internal representation
 /// of color
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub struct RGBAColor(pub(crate) u8, pub(crate) u8, pub(crate) u8, pub(crate) f64);
 
 impl BackendStyle for RGBAColor {
@@ -89,7 +91,7 @@ impl<P: Palette> BackendStyle for PaletteColor<P> {
 impl<P: Palette> Color for PaletteColor<P> {}
 
 /// The color described by its RGB value
-#[derive(Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct RGBColor(pub u8, pub u8, pub u8);
 
 impl BackendStyle for RGBColor {

--- a/src/style/shape.rs
+++ b/src/style/shape.rs
@@ -28,8 +28,8 @@ impl ShapeStyle {
     }
 }
 
-impl<'a, T: Color> From<&'a T> for ShapeStyle {
-    fn from(f: &'a T) -> Self {
+impl<T: Color> From<T> for ShapeStyle {
+    fn from(f: T) -> Self {
         ShapeStyle {
             color: f.to_rgba(),
             filled: false,


### PR DESCRIPTION
This fixes a bit of a usability issue with the API of plotters where
certain functions only take references to colors, even if an owned value
is easily available. Especially if the same builder pattern takes
multiple colors, it's extremely annoying if the color cannot be
initialized once and then copied around.