### PR TITLE
fix UB in minifb example

### DIFF
--- a/examples/minifb-demo/src/main.rs
+++ b/examples/minifb-demo/src/main.rs
@@ -5,11 +5,48 @@ use plotters_bitmap::BitMapBackend;
 use std::collections::VecDeque;
 use std::error::Error;
 use std::time::SystemTime;
+use std::borrow::{Borrow, BorrowMut};
 const W: usize = 480;
 const H: usize = 320;
 
 const SAMPLE_RATE: f64 = 10_000.0;
 const FREAME_RATE: f64 = 30.0;
+
+struct BufferWrapper(Vec<u32>);
+impl Borrow<[u8]> for BufferWrapper {
+    fn borrow(&self) -> &[u8] {
+        // Safe for alignment: align_of(u8) <= align_of(u32)
+        // Safe for cast: u32 can be thought of as being transparent over [u8; 4]
+        unsafe {
+            std::slice::from_raw_parts(
+                self.0.as_ptr() as *const u8,
+                self.0.len() * 4
+            )
+        }
+    }
+}
+impl BorrowMut<[u8]> for BufferWrapper {
+    fn borrow_mut(&mut self) -> &mut [u8] {
+        // Safe for alignment: align_of(u8) <= align_of(u32)
+        // Safe for cast: u32 can be thought of as being transparent over [u8; 4]
+        unsafe {
+            std::slice::from_raw_parts_mut(
+                self.0.as_mut_ptr() as *mut u8,
+                self.0.len() * 4
+            )
+        }
+    }
+}
+impl Borrow<[u32]> for BufferWrapper {
+    fn borrow(&self) -> &[u32] {
+        self.0.as_slice()
+    }
+}
+impl BorrowMut<[u32]> for BufferWrapper {
+    fn borrow_mut(&mut self) -> &mut [u32] {
+        self.0.as_mut_slice()
+    }
+}
 
 fn get_window_title(fx: f64, fy: f64, iphase: f64) -> String {
     format!(
@@ -19,7 +56,7 @@ fn get_window_title(fx: f64, fy: f64, iphase: f64) -> String {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let mut buf = vec![0u8; W * H * 4];
+    let mut buf = BufferWrapper(vec![0u32; W * H]);
 
     let mut fx: f64 = 1.0;
     let mut fy: f64 = 1.1;
@@ -33,7 +70,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         WindowOptions::default(),
     )?;
     let root =
-        BitMapBackend::<BGRXPixel>::with_buffer_and_format(&mut buf[..], (W as u32, H as u32))?
+        BitMapBackend::<BGRXPixel>::with_buffer_and_format(buf.borrow_mut(), (W as u32, H as u32))?
             .into_drawing_area();
     root.fill(&BLACK)?;
 
@@ -81,7 +118,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         if epoch - last_flushed > 1.0 / FREAME_RATE {
             let root = BitMapBackend::<BGRXPixel>::with_buffer_and_format(
-                &mut buf[..],
+                buf.borrow_mut(),
                 (W as u32, H as u32),
             )?
             .into_drawing_area();
@@ -134,8 +171,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                     break;
                 }
             }
-            let buf = unsafe { std::slice::from_raw_parts(&buf[0] as *const _ as *const _, H * W) };
-            window.update_with_buffer(buf)?;
+
+            window.update_with_buffer(buf.borrow())?;
             last_flushed = epoch;
         }
 


### PR DESCRIPTION
In the minifb example a `Vec<u8>` was allocated and then used as bitmap backend target. Later this same buffer was cast to `&[u32]` using this code:

```rs
unsafe {
    std::slice::from_raw_parts(&buf[0] as *const _ as *const _, H * W)
}
```

This is incorrect because of two things:
* `&buf[0]` semantically borrows the first element and then creates a pointer from the borrow. This is ok in partice but in the abstract machine it creates an access past the borrowed memory of the first element and it might break in the future.
* The alignment of `u8` is 1 while the alignment of `u32` is 4. This is not a huge problem on x86, but would probably crash on ARM. Run this playground in Miri to see it panics: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=d7e15efe2d8bc611692d6350919e7943

The first problem can be solved by using the std functions `vec.as_ptr()` and `vec.as_mut_ptr()` which are guaranteed to work correctly because it's std.

The second problem can be solved by using `Vec<u32>` and casting it to `&mut [u8]`, since having higher alignment than required is ok.