### PR TITLE
Avoid `attempt to divide by zero` when x-axis is datetime

### DIFF
--- a/src/coord/ranged1d/types/datetime.rs
+++ b/src/coord/ranged1d/types/datetime.rs
@@ -200,6 +200,12 @@ where
             return ret;
         }
 
+        // When all data is in the same week, just plot properly.
+        if total_weeks == 0 {
+            ret.push(self.0.clone());
+            return ret;
+        }
+
         let week_per_point = ((total_weeks as f64) / (max_points as f64)).ceil() as usize;
 
         for idx in 0..=(total_weeks as usize / week_per_point) {


### PR DESCRIPTION
When we use datetime type for x-axis and the data is in the same week, this crate crashes with saying `panicked at 'attempt to divide by zero'`.

This is caused by the calculation of the number of points in a week.
When all data is in a week, `num_weeks()` method returns 0 and results in panic.

close https://github.com/38/plotters/issues/190