### PR TITLE
Exclude plotters-doc-data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://plotters-rs.github.io/"
 keywords = ["WebAssembly", "Visualization", "Plotting", "Drawing"]
 categories = ["visualization", "wasm"]
 readme = "README.md"
-exclude = ["doc-template/*"]
+exclude = ["doc-template", "plotters-doc-data"]
 
 [dependencies]
 num-traits = "0.2.14"


### PR DESCRIPTION
The `plotters-doc-data` submodule is included in the published crate, giving it a compressed size of 8.8MiB, this just removes it bringing the crate down to a much more reasonable 143KiB.