### PR TITLE
upgrade ttf-parser to 0.15.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ optional = true
 default_features = false
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ttf-parser = { version = "0.12.0", optional = true }
+ttf-parser = { version = "0.15.0", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 pathfinder_geometry = { version = "0.5.1", optional = true }
 font-kit = { version = "0.10.0", optional = true }

--- a/src/style/font/ttf.rs
+++ b/src/style/font/ttf.rs
@@ -91,13 +91,15 @@ impl FontExt {
 
     fn query_kerning_table(&self, prev: u32, next: u32) -> f32 {
         if let Some(face) = self.face.as_ref() {
-            let kern = face
-                .kerning_subtables()
-                .filter(|st| st.is_horizontal() && !st.is_variable())
-                .filter_map(|st| st.glyphs_kerning(GlyphId(prev as u16), GlyphId(next as u16)))
-                .next()
-                .unwrap_or(0);
-            return kern as f32;
+            if let Some(kern) = face.tables().kern {
+                let kern = kern
+                    .subtables.into_iter()
+                    .filter(|st| st.horizontal && !st.variable)
+                    .filter_map(|st| st.glyphs_kerning(GlyphId(prev as u16), GlyphId(next as u16)))
+                    .next()
+                    .unwrap_or(0);
+                return kern as f32;
+            }
         }
         0.0
     }


### PR DESCRIPTION
.kerning_subtables() have changed name to .tables().kern.subtables and .is_horizontal(), .is_variable() to .horizontal and .variable