### PR TITLE
Exposing LogRangeExt

### DIFF
--- a/plotters/src/coord/ranged1d/combinators/mod.rs
+++ b/plotters/src/coord/ranged1d/combinators/mod.rs
@@ -8,7 +8,7 @@ mod linspace;
 pub use linspace::{IntoLinspace, Linspace};
 
 mod logarithmic;
-pub use logarithmic::{IntoLogRange, LogCoord, LogScalable};
+pub use logarithmic::{IntoLogRange, LogCoord, LogScalable, LogRangeExt};
 
 #[allow(deprecated)]
 pub use logarithmic::LogRange;


### PR DESCRIPTION
LogRangeExt was not exposed and as such, users could not define their custom log range