### PR TITLE
For the DualCoordChartContext add borrow_secondary_mut function

### DIFF
--- a/plotters/src/chart/dual_coord.rs
+++ b/plotters/src/chart/dual_coord.rs
@@ -131,10 +131,16 @@ impl<'a, DB: DrawingBackend, CT1: CoordTranslate, CT2: CoordTranslate>
         &self.secondary.drawing_area
     }
 
-    /// Borrow a mutable reference to the chart context that uses the secondary
+    /// Borrow a reference to the chart context that uses the secondary
     /// coordinate system
     pub fn borrow_secondary(&self) -> &ChartContext<'a, DB, CT2> {
         &self.secondary
+    }
+
+    /// Borrow a mutable reference to the chart context that uses the secondary
+    /// coordinate system
+    pub fn borrow_secondary_mut(&mut self) -> &mut ChartContext<'a, DB, CT2> {
+        &mut self.secondary
     }
 }
 


### PR DESCRIPTION
The function borrow_secondary function does not return a mutable reference. It would be useful if it actually would be possible to get a &mut reference to the secondary context.
Implement a new function that actually return a &mut reference to the secondary context.

For example to write a generic draw function:
```rust 
    fn draw_chart_series<DB>(
        chart: &mut ChartContext<'_, DB, Cartesian2d<RangedCoordf32, RangedCoordf32>>,
        data_series: &ModelRc<XYData>,
    ) where
        DB: DrawingBackend,
    {
        // draw the chart series for both primary and secondary
   }
```
