### PR TITLE
add support for disabling anti-aliasing in BitmapBackend

### DIFF
--- a/plotters-backend/src/lib.rs
+++ b/plotters-backend/src/lib.rs
@@ -326,4 +326,10 @@ pub trait DrawingBackend: Sized {
 
         Ok(())
     }
+
+    /// Utilize anti-aliasing if supported by the chosen backend.
+    /// By default this option is true.
+    fn use_anti_aliasing(&self) -> bool {
+        true
+    }
 }

--- a/plotters-backend/src/rasterizer/circle.rs
+++ b/plotters-backend/src/rasterizer/circle.rs
@@ -106,16 +106,20 @@ fn draw_sweep_line<B: DrawingBackend, S: BackendStyle>(
             (p0 + x0, e.floor() as i32 + y0),
             &style.color()
         ));
-        check_result!(b.draw_pixel((p0 + x0, s.ceil() as i32 + y0 - 1), style.color().mix(vs)));
-        check_result!(b.draw_pixel((p0 + x0, e.floor() as i32 + y0 + 1), style.color().mix(ve)));
-    } else {
+        if b.use_anti_aliasing() {
+            check_result!(b.draw_pixel((p0 + x0, s.ceil() as i32 + y0 - 1), style.color().mix(vs)));
+            check_result!(b.draw_pixel((p0 + x0, e.floor() as i32 + y0 + 1), style.color().mix(ve)));
+        }
+    } else if b.use_anti_aliasing() {
         check_result!(b.draw_line(
             (s.ceil() as i32 + x0, p0 + y0),
             (e.floor() as i32 + x0, p0 + y0),
             &style.color()
         ));
-        check_result!(b.draw_pixel((s.ceil() as i32 + x0 - 1, p0 + y0), style.color().mix(vs)));
-        check_result!(b.draw_pixel((e.floor() as i32 + x0 + 1, p0 + y0), style.color().mix(ve)));
+        if b.use_anti_aliasing() {
+            check_result!(b.draw_pixel((s.ceil() as i32 + x0 - 1, p0 + y0), style.color().mix(vs)));
+            check_result!(b.draw_pixel((e.floor() as i32 + x0 + 1, p0 + y0), style.color().mix(ve)));
+        }
     }
 
     Ok(())
@@ -319,22 +323,24 @@ pub fn draw_circle<B: DrawingBackend, S: BackendStyle>(
         let top = center.1 - lx.floor() as i32;
         let bottom = center.1 + lx.floor() as i32;
 
+        // Do not use flat color but interpolate when using anti-aliasing
         if fill {
             check_result!(b.draw_line((left, y), (right, y), &style.color()));
             check_result!(b.draw_line((x, top), (x, up - 1), &style.color()));
             check_result!(b.draw_line((x, down + 1), (x, bottom), &style.color()));
-        } else {
+        } else if b.use_anti_aliasing() {
             check_result!(b.draw_pixel((left, y), style.color().mix(1.0 - v)));
             check_result!(b.draw_pixel((right, y), style.color().mix(1.0 - v)));
 
             check_result!(b.draw_pixel((x, top), style.color().mix(1.0 - v)));
             check_result!(b.draw_pixel((x, bottom), style.color().mix(1.0 - v)));
         }
-
-        check_result!(b.draw_pixel((left - 1, y), style.color().mix(v)));
-        check_result!(b.draw_pixel((right + 1, y), style.color().mix(v)));
-        check_result!(b.draw_pixel((x, top - 1), style.color().mix(v)));
-        check_result!(b.draw_pixel((x, bottom + 1), style.color().mix(v)));
+        if b.use_anti_aliasing() {
+            check_result!(b.draw_pixel((left - 1, y), style.color().mix(v)));
+            check_result!(b.draw_pixel((right + 1, y), style.color().mix(v)));
+            check_result!(b.draw_pixel((x, top - 1), style.color().mix(v)));
+            check_result!(b.draw_pixel((x, bottom + 1), style.color().mix(v)));
+        }
     }
 
     Ok(())

--- a/plotters-backend/src/rasterizer/line.rs
+++ b/plotters-backend/src/rasterizer/line.rs
@@ -81,10 +81,15 @@ pub fn draw_line<DB: DrawingBackend, S: BackendStyle>(
     let grad = f64::from(to.1 - from.1) / f64::from(to.0 - from.0);
 
     let mut put_pixel = |(x, y): BackendCoord, b: f64| {
-        if steep {
-            back.draw_pixel((y, x), style.color().mix(b))
+        // Do not use flat color but interpolate when using anti-aliasing
+        if back.use_anti_aliasing() {
+            if steep {
+                back.draw_pixel((y, x), style.color().mix(b))
+            } else {
+                back.draw_pixel((x, y), style.color().mix(b))
+            }
         } else {
-            back.draw_pixel((x, y), style.color().mix(b))
+            Ok(())
         }
     };
 

--- a/plotters-backend/src/rasterizer/polygon.rs
+++ b/plotters-backend/src/rasterizer/polygon.rs
@@ -201,33 +201,39 @@ pub fn fill_polygon<DB: DrawingBackend, S: BackendStyle>(
                         }
 
                         if horizontal_sweep {
+                            // Do not use flat color but interpolate when using anti-aliasing
                             check_result!(back.draw_line(
                                 (sweep_line, from.ceil() as i32),
                                 (sweep_line, to.floor() as i32),
                                 &style.color(),
                             ));
-                            check_result!(back.draw_pixel(
-                                (sweep_line, from.floor() as i32),
-                                style.color().mix(from.ceil() - from),
-                            ));
-                            check_result!(back.draw_pixel(
-                                (sweep_line, to.ceil() as i32),
-                                style.color().mix(to - to.floor()),
-                            ));
+                            if back.use_anti_aliasing() {
+                                check_result!(back.draw_pixel(
+                                    (sweep_line, from.floor() as i32),
+                                    style.color().mix(from.ceil() - from)
+                                ));
+                                check_result!(back.draw_pixel(
+                                    (sweep_line, to.ceil() as i32),
+                                    style.color().mix(to - to.floor())
+                                ));
+                            }
                         } else {
+                            // Do not use flat color but interpolate when using anti-aliasing
                             check_result!(back.draw_line(
                                 (from.ceil() as i32, sweep_line),
                                 (to.floor() as i32, sweep_line),
                                 &style.color(),
                             ));
-                            check_result!(back.draw_pixel(
-                                (from.floor() as i32, sweep_line),
-                                style.color().mix(from.ceil() - from),
-                            ));
-                            check_result!(back.draw_pixel(
-                                (to.ceil() as i32, sweep_line),
-                                style.color().mix(to.floor() - to),
-                            ));
+                            if back.use_anti_aliasing() {
+                                check_result!(back.draw_pixel(
+                                    (from.floor() as i32, sweep_line),
+                                    style.color().mix(from.ceil() - from)
+                                ));
+                                check_result!(back.draw_pixel(
+                                    (to.ceil() as i32, sweep_line),
+                                    style.color().mix(to.floor() - to)
+                                ));
+                            }
                         }
 
                         first = None;

--- a/plotters-bitmap/src/bitmap.rs
+++ b/plotters-bitmap/src/bitmap.rs
@@ -40,6 +40,7 @@ pub struct BitMapBackend<'a, P: PixelFormat = RGBPixel> {
     buffer: Buffer<'a>,
     /// Flag indicates if the bitmap has been saved
     saved: bool,
+    use_anti_aliasing: bool,
     _phantomdata: PhantomData<P>,
 }
 
@@ -57,6 +58,7 @@ impl<'a> BitMapBackend<'a, RGBPixel> {
             size: (w, h),
             buffer: Buffer::Owned(vec![0; Self::PIXEL_SIZE * (w * h) as usize]),
             saved: false,
+            use_anti_aliasing: true,
             _phantomdata: PhantomData,
         }
     }
@@ -85,6 +87,7 @@ impl<'a> BitMapBackend<'a, RGBPixel> {
             size: (w, h),
             buffer: Buffer::Owned(vec![0; Self::PIXEL_SIZE * (w * h) as usize]),
             saved: false,
+            use_anti_aliasing: true,
             _phantomdata: PhantomData,
         })
     }
@@ -128,6 +131,7 @@ impl<'a, P: PixelFormat> BitMapBackend<'a, P> {
             size: (w, h),
             buffer: Buffer::Borrowed(buf),
             saved: false,
+            use_anti_aliasing: true,
             _phantomdata: PhantomData,
         })
     }
@@ -135,6 +139,13 @@ impl<'a, P: PixelFormat> BitMapBackend<'a, P> {
     #[inline(always)]
     pub(crate) fn get_raw_pixel_buffer(&mut self) -> &mut [u8] {
         self.buffer.borrow_buffer()
+    }
+
+    #[inline(always)]
+    pub fn anti_aliasing(self, use_anti_aliasing: bool) -> Self {
+        let mut s = self;
+        s.use_anti_aliasing = use_anti_aliasing;
+        s
     }
 
     /// Split a bitmap backend vertically into several sub drawing area which allows
@@ -333,6 +344,10 @@ impl<'a, P: PixelFormat> DrawingBackend for BitMapBackend<'a, P> {
         }
 
         Ok(())
+    }
+
+    fn use_anti_aliasing(&self) -> bool {
+        self.use_anti_aliasing
     }
 }
 

--- a/plotters-svg/src/svg.rs
+++ b/plotters-svg/src/svg.rs
@@ -662,6 +662,10 @@ impl<'a> DrawingBackend for SVGBackend<'a> {
 
         Ok(())
     }
+
+    fn use_anti_aliasing(&self) -> bool {
+        true
+    }
 }
 
 impl Drop for SVGBackend<'_> {

--- a/plotters/src/lib.rs
+++ b/plotters/src/lib.rs
@@ -753,8 +753,8 @@ pub fn register_font(
     Since Plotters 0.3, all drawing backends are independent crate from the main Plotters crate.
     Use the following link to find the backend code:
 
-    - [Bitmap Backend](https://github.com/plotters-rs/plotters-bitmap.git)
-    - [SVG Backend](https://github.com/plotters-rs/plotters-svg.git)
+    - [Bitmap Backend](https://github.com/plotters-rs/plotters/tree/master/plotters-bitmap)
+    - [SVG Backend](https://github.com/plotters-rs/plotters/tree/master/plotters-svg)
     - [HTML5 Canvas Backend](https://github.com/plotters-rs/plotters-canvas.git)
     - [GTK/Cairo Backend](https://github.com/plotters-rs/plotters-cairo.git)
 


### PR DESCRIPTION
## Description
This PR arose from a personal need where I wanted to quickly draw some geometries but they had to be solid of identical color. In this scenario, anti-aliasing is actually undesirable. Since I saw no functionality to disable this, I added it.

The PR does not yet contain any tests. I would love to hear some feedback if this approach is reasonable.
The introduction of a new defaulted method `fn use_anti_aliasing(&self) -> bool` to the `DrawingBackend` trait would probably be classified as a minor change by Rust's semver-specs https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-default thus requiring a minor version bump. However, I am happy to hear any feedback on this.

## Example Usage
```rust
let (x, y) = ..;
let mut buffer = vec![0u8; x*y*3];
BitMapBackend::with_buffer(&mut buffer, (x, y))
    .anti_aliasing(false)
    .into_drawing_area();
```