### PR TITLE
feat: add tooltip support

### DIFF
--- a/plotters-backend/src/style.rs
+++ b/plotters-backend/src/style.rs
@@ -1,5 +1,5 @@
 /// The color type that is used by all the backend
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct BackendColor {
     pub alpha: f64,
     pub rgb: (u8, u8, u8),

--- a/plotters/examples/interactive_tooltips.rs
+++ b/plotters/examples/interactive_tooltips.rs
@@ -1,0 +1,79 @@
+//! Interactive SVG tooltips examples.
+//!
+//! This example demonstrates the `draw_series_with_tooltips` API together with
+//! `SVGBackend::with_tooltips()`. The generated SVG file contains embedded CSS and JavaScript that
+//! show a tooltip on hover for every data point.
+//!
+//! Open `plotters-doc-data/interactive_tooltips.svg` in a browser to see it in action.
+
+use plotters::prelude::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let path = "plotters-doc-data/interactive_tooltips.svg";
+
+    // Make sure the output directory exists
+    std::fs::create_dir_all("plotters-doc-data")?;
+
+    let root = SVGBackend::new(path, (720, 460))
+        .with_tooltips()
+        .into_drawing_area();
+
+    root.fill(&WHITE);
+
+    let mut chart = ChartBuilder::on(&root)
+        .caption("Interactive Tooltips Demo", ("sans-serif", 28).into_font())
+        .margin(10)
+        .x_label_area_size(40)
+        .y_label_area_size(50)
+        .build_cartesian_2d(0f64..6.5, -1.2..1.2)?;
+
+    chart.configure_mesh().x_desc("X").y_desc("Y").draw()?;
+
+    // --- Series 1: sin(x) ---
+    let sin_data: Vec<_> = (0..=60)
+        .map(|i| {
+            let x = i as f64 / 10.;
+            (x, x.sin())
+        })
+        .collect();
+
+    chart
+        .draw_series_with_tooltips(
+            LineSeries::new(sin_data.iter().copied(), &RED),
+            &RED,
+            "sin(x)",
+        )?
+        .label("sin(x)")
+        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], RED));
+
+    // --- Series 2: cos(x) ---
+    let cos_data: Vec<_> = (0..=60)
+        .map(|i| {
+            let x = i as f64 / 10.;
+            (x, x.cos())
+        })
+        .collect();
+
+    chart
+        .draw_series_with_tooltips(
+            LineSeries::new(cos_data.iter().copied(), &BLUE).point_size(3),
+            &BLUE,
+            "cos(x)",
+        )?
+        .label("cos(x)")
+        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], BLUE));
+
+    chart
+        .configure_series_labels()
+        .border_style(BLACK)
+        .background_style(WHITE.mix(0.8))
+        .position(SeriesLabelPosition::UpperRight)
+        .draw()?;
+
+    root.present()?;
+
+    println!("Chart saved to {path}");
+    println!("Open it in a web browser to see interactive tooltips on hover");
+
+    Ok(())
+}

--- a/plotters/src/chart/builder.rs
+++ b/plotters/src/chart/builder.rs
@@ -432,6 +432,7 @@ impl<'a, 'b, DB: DrawingBackend> ChartBuilder<'a, 'b, DB> {
                 pixel_range,
             )),
             series_anno: vec![],
+            next_series_id: 0,
             drawing_area_pos: (
                 actual_drawing_area_pos[2] + title_dx + self.margin[2] as i32,
                 actual_drawing_area_pos[0] + title_dy + self.margin[0] as i32,
@@ -491,6 +492,7 @@ impl<'a, 'b, DB: DrawingBackend> ChartBuilder<'a, 'b, DB> {
                 pixel_range,
             )),
             series_anno: vec![],
+            next_series_id: 0,
             drawing_area_pos: (
                 title_dx + self.margin[2] as i32,
                 title_dy + self.margin[0] as i32,

--- a/plotters/src/chart/context/cartesian2d/mod.rs
+++ b/plotters/src/chart/context/cartesian2d/mod.rs
@@ -1,14 +1,16 @@
+use std::borrow::Borrow;
 use std::ops::Range;
 
-use plotters_backend::{BackendCoord, DrawingBackend};
-
-use crate::chart::{ChartContext, DualCoordChartContext, MeshStyle};
+use crate::chart::{ChartContext, DualCoordChartContext, MeshStyle, SeriesAnno};
 use crate::coord::{
     cartesian::Cartesian2d,
     ranged1d::{AsRangedCoord, Ranged, ValueFormatter},
     Shift,
 };
-use crate::drawing::DrawingArea;
+use crate::drawing::{DrawingArea, DrawingAreaErrorKind};
+use crate::element::{CoordMapper, Drawable, PointCollection};
+use crate::style::Color;
+use plotters_backend::{BackendCoord, DrawingBackend, Interpolation};
 
 mod draw_impl;
 
@@ -43,6 +45,102 @@ where
     /// the function `MeshStyle::draw`.
     pub fn configure_mesh(&mut self) -> MeshStyle<'a, '_, X, Y, DB> {
         MeshStyle::new(self)
+    }
+
+    /// Draw a series while emitting semantic contexts for every element.
+    ///
+    /// This is the tooltip-aware counterpart of [`ChartContext::draw_series`].
+    /// Each element in the iterator must yield guest coordinates `(XT, YT)`.
+    /// The method inspects each element's points:
+    ///
+    /// - **Single-point** elements (markers, circles) are wrapped in a
+    /// [`ElementContext::DataPoint`] context with formatted x/y labels.
+    /// - **Multi-point** elements (lines, paths) are wrapped in a [`ElementContext::DataLine`]
+    /// context that carries discrete interpolation data (every vertex with its formatted label).
+    ///
+    /// The whole series is wrapped in a [`ElementContext::DataSeries`] context so interactive
+    /// backends can group and style them.
+    ///
+    /// `series_color` and `series_label` describe the series metadata forwarded to the backend.
+    pub fn draw_series_with_tooltips<B, E, R, S, C>(
+        &mut self,
+        series: S,
+        series_color: &C,
+        series_label: &str,
+    ) -> Result<&mut SeriesAnno<'a, DB>, DrawingAreaErrorKind<DB::ErrorType>>
+    where
+        B: CoordMapper,
+        for<'b> &'b E: PointCollection<'b, (XT, YT), B>,
+        E: Drawable<DB, B>,
+        R: Borrow<E>,
+        S: IntoIterator<Item = R>,
+        C: Color,
+    {
+        let series_id = self.next_series_id;
+        self.next_series_id += 1;
+
+        let bc = series_color.to_backend_color();
+        self.drawing_area
+            .begin_context(plotters_backend::ElementContext::DataSeries {
+                id: series_id,
+                color: bc,
+                label: series_label.to_string(),
+            })?;
+
+        let x_spec = self.drawing_area.as_coord_spec().x_spec();
+        let y_spec = self.drawing_area.as_coord_spec().y_spec();
+
+        for element in series {
+            let elem = element.borrow();
+
+            // Collect all guest points and map them to backend coords + labels
+            let mapped: Vec<_> = elem
+                .point_iter()
+                .into_iter()
+                .map(|pt| {
+                    let guest = pt.borrow();
+                    let xl = X::format_ext(x_spec, &guest.0);
+                    let yl = Y::format_ext(y_spec, &guest.1);
+                    let coord = self.drawing_area.map_coordinate(guest);
+                    (coord, xl, yl)
+                })
+                .collect();
+
+            let opened = if mapped.len() <= 1 {
+                // Single-point element->DataPoint context
+                if let Some((coord, xl, yl)) = mapped.into_iter().next() {
+                    self.drawing_area.begin_context(
+                        plotters_backend::ElementContext::DataPoint {
+                            coord,
+                            x_label: xl,
+                            y_label: yl,
+                            series_id,
+                        },
+                    )?;
+                    true
+                } else {
+                    false
+                }
+            } else {
+                // Multi-point element -> DataLine context with discrete interpolation (every vertex
+                // carries a formatted label).
+                let x_points: Vec<_> = mapped.iter().map(|(c, xl, _)| (c.0, xl.clone())).collect();
+                let y_points: Vec<_> = mapped.iter().map(|(c, _, yl)| (c.1, yl.clone())).collect();
+                self.drawing_area
+                    .begin_context(plotters_backend::ElementContext::DataLine {
+                        x_interpolation: Interpolation::Discrete { points: x_points },
+                        y_interpolation: Interpolation::Discrete { points: y_points },
+                        series_id,
+                    })?;
+                true
+            };
+            self.drawing_area.draw(elem)?;
+            if opened {
+                self.drawing_area.end_context()?;
+            }
+        }
+        self.drawing_area.end_context()?; // close DataSeries
+        Ok(self.alloc_series_anno())
     }
 }
 

--- a/plotters/src/chart/dual_coord.rs
+++ b/plotters/src/chart/dual_coord.rs
@@ -121,6 +121,7 @@ impl<'a, DB: DrawingBackend, CT1: CoordTranslate, CT2: CoordTranslate>
                 y_label_area: secondary_y_label_area,
                 drawing_area: secondary_drawing_area,
                 series_anno: vec![],
+                next_series_id: 0,
                 drawing_area_pos: (0, 0),
             },
         }

--- a/plotters/src/chart/state.rs
+++ b/plotters/src/chart/state.rs
@@ -106,6 +106,7 @@ impl<CT: CoordTranslate> ChartState<CT> {
             y_label_area: [None, None],
             drawing_area: area.apply_coord_spec(self.coord),
             series_anno: vec![],
+            next_series_id: 0,
             drawing_area_pos: self.drawing_area_pos,
         }
     }

--- a/plotters/src/lib.rs
+++ b/plotters/src/lib.rs
@@ -833,6 +833,7 @@ pub mod prelude {
 
     // Re-export the backend for backward compatibility
     pub use plotters_backend::DrawingBackend;
+    pub use plotters_backend::{ElementContext, Interpolation};
 
     pub use crate::drawing::*;
 


### PR DESCRIPTION
fixes https://github.com/plotters-rs/plotters/issues/13
It works, but I don't like the presence of
* DrawingBackend::with_tooltips function
   tooltip should be enabled per chart, not backend.
* `draw_series_with_tooltips` api.
  Ideally, it should work with draw_series API and tooltip should be a configuration parameter.

Challenge:
* The library gives user the control over when to draw. Because of this, we don't have enough information in draw_series to emit the tooltips code.

Alternative API:
* `chart.tooltip_mode(TooltipMode)` shall enable tooltips for current chart.
   mode can be "Auto", "Always", "Disable". If Always and the backend doesn't support, there should be error.
* On every draw ( and .label, etc) call, keep on building internal state.
   Also, SVG backend shall add classes wherever required to uniquely identify elements, if tooltip mode is enabled.
* On present call, add javascript to enable tooltips.

Question to the maintainers:
* Does the API feel satisfactory, or do you have better suggestions?

<img width="715" height="449" alt="image" src="https://github.com/user-attachments/assets/9af61435-a4af-40f4-b9f9-1ff485740000" />

AI use:
The initial approach, including the API was designed after manual experiments. AI is used to scale the approach into a wider & cleaner solution.